### PR TITLE
Pin flake-compat version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,1 @@
-(import (builtins.fetchTarball "https://github.com/edolstra/flake-compat/archive/master.tar.gz") {
-  src = ./.;
-}).defaultNix.default
+(import ./flake-compat.nix).defaultNix.default

--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -1,0 +1,9 @@
+let
+  flake-compat = builtins.fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+  };
+in
+(import flake-compat {
+  src = ./.;
+})

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,1 @@
-(import (builtins.fetchTarball "https://github.com/edolstra/flake-compat/archive/master.tar.gz") {
-  src = ./.;
-}).shellNix.default
+(import ./flake-compat.nix).shellNix.default


### PR DESCRIPTION
This pins the version to the latest commit, and checks the hash for it.

Fixes #16.