### PR TITLE
Allow dot-completion for attributes

### DIFF
--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -35,7 +35,7 @@ impl App {
         file: Url,
         root: &SyntaxNode,
         offset: usize,
-    ) -> Option<(Ident, HashMap<String, (Datatype, Option<Var>)>)> {
+    ) -> Option<(Ident, HashMap<String, (Datatype, Option<Var>)>, String)> {
         let mut file = Rc::new(file);
         let info = utils::ident_at(&root, offset)?;
         let ident = info.ident;
@@ -57,7 +57,7 @@ impl App {
                 }
             }
         }
-        Some((Ident::cast(ident.node().clone()).unwrap(), entries))
+        Some((Ident::cast(ident.node().clone()).unwrap(), entries, info.name))
     }
     pub fn scope_from_node(
         &mut self,

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,7 +247,7 @@ impl App {
         let (current_ast, current_content) = self.files.get(&params.text_document.uri)?;
         let offset = utils::lookup_pos(current_content, params.position)?;
         let node = current_ast.node();
-        let (name, scope) = self.scope_for_ident(params.text_document.uri, &node, offset)?;
+        let (name, scope, _) = self.scope_for_ident(params.text_document.uri, &node, offset)?;
 
         let var_e = scope.get(name.as_str())?;
         if let (_, Some(var)) = var_e {
@@ -266,7 +266,7 @@ impl App {
         let offset = utils::lookup_pos(content, params.position)?;
 
         let node = ast.node();
-        let (name, scope) =
+        let (node, scope, name) =
             self.scope_for_ident(params.text_document.uri.clone(), &node, offset)?;
 
         // Re-open, because scope_for_ident may mutably borrow
@@ -278,7 +278,7 @@ impl App {
                 completions.push(CompletionItem {
                     label: var.clone(),
                     text_edit: Some(TextEdit {
-                        range: utils::range(content, name.node().text_range()),
+                        range: utils::range(content, node.node().text_range()),
                         new_text: var.clone(),
                     }),
                     detail: Some(datatype.to_string()),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,13 +70,46 @@ pub fn range(code: &str, range: TextRange) -> Range {
 pub struct CursorInfo {
     pub path: Vec<String>,
     pub ident: Ident,
+    pub name: String,
 }
+
+impl CursorInfo {
+    pub fn new(path: Vec<String>, ident: Ident, name: Option<String>) -> CursorInfo {
+        let myname = match name {
+            Some(n) => n,
+            None => String::from((Ident::cast(ident.node().clone()).unwrap()).as_str()),
+        };
+
+        CursorInfo {
+            path,
+            ident,
+            name: myname,
+        }
+    }
+}
+
 pub fn ident_at(root: &SyntaxNode, offset: usize) -> Option<CursorInfo> {
+    let mut add = false;
     let ident = match root.token_at_offset(TextUnit::from_usize(offset)) {
         TokenAtOffset::None => None,
         TokenAtOffset::Single(node) => Ident::cast(node.parent()),
         TokenAtOffset::Between(left, right) => {
-            Ident::cast(left.parent()).or_else(|| Ident::cast(right.parent()))
+            let result = Ident::cast(left.parent()).or_else(|| Ident::cast(right.parent()));
+            match result {
+                Some(_) => result,
+                None => {
+                    if let Some(sel) = Select::cast(left.parent()) {
+                        add = true;
+                        if let Some(s) = sel.set().and_then(Select::cast) {
+                            Ident::cast(s.index()?)
+                        } else {
+                            Ident::cast(sel.set()?)
+                        }
+                    } else {
+                        None
+                    }
+                },
+            }
         }
     }?;
     let parent = ident.node().parent();
@@ -84,10 +117,11 @@ pub fn ident_at(root: &SyntaxNode, offset: usize) -> Option<CursorInfo> {
         if let Some(node) = node.from() {
             if let Some(tok) = node.inner() {
                 if let Some(_) = Ident::cast(tok.clone()) {
-                    return Some(CursorInfo {
-                        path: vec![tok.text().to_string()],
-                        ident: ident.clone(),
-                    })
+                    return Some(CursorInfo::new(
+                        vec![tok.text().to_string()],
+                        ident.clone(),
+                        None,
+                    ))
                 } else if let Some(mut attr) = Select::cast(tok.clone()) {
                     let mut result = Vec::new();
                     result.push(attr.index()?.to_string().into());
@@ -97,23 +131,25 @@ pub fn ident_at(root: &SyntaxNode, offset: usize) -> Option<CursorInfo> {
                     }
                     result.push(Ident::cast(attr.set()?)?.as_str().into());
                     result.reverse();
-                    return Some(CursorInfo {
-                        path: result,
-                        ident: ident.clone(),
-                    })
+                    return Some(CursorInfo::new(
+                        result,
+                        ident.clone(),
+                        None,
+                    ))
                 }
             }
         }
-        Some(CursorInfo {
-            path: Vec::new(),
+        Some(CursorInfo::new(
+            Vec::new(),
             ident,
-        })
+            None
+        ))
     }
     else if let Some(attr) = parent.clone().and_then(Key::cast) {
         let mut path = Vec::new();
         for item in attr.path() {
             if item == *ident.node() {
-                return Some(CursorInfo { path, ident });
+                return Some(CursorInfo::new(path, ident, None));
             }
 
             path.push(Ident::cast(item)?.as_str().into());
@@ -133,12 +169,19 @@ pub fn ident_at(root: &SyntaxNode, offset: usize) -> Option<CursorInfo> {
             path.push(Ident::cast(index.set()?)?.as_str().into());
         }
         path.reverse();
-        Some(CursorInfo { path, ident })
+        if add {
+            path.push(String::from(ident.as_str()));
+        }
+        Some(CursorInfo::new(path, ident, match add {
+            true => Some(String::from("")),
+            false => None,
+        }))
     } else {
-        Some(CursorInfo {
-            path: Vec::new(),
+        Some(CursorInfo::new(
+            Vec::new(),
             ident,
-        })
+            None
+        ))
     }
 }
 


### PR DESCRIPTION
When I write `builtins.`, it wasn't possible until now to list all
attributes in `builtins` (or any other indexed attr-set).

This happened because in that case `utils::ident_at` found `NODE_SELECT`
for the current token (i.e. `TOKEN_DOT`) and not `NODE_IDENT`. This
patch handles the case where `NODE_SELECT` is the current token and
searches for the last `NODE_IDENT`.

cc @jD91mZM2 