### PR TITLE
Add `var` from `{ a, b, c }@var` to scope

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -270,6 +270,20 @@ pub fn scope_for(file: &Rc<Url>, node: SyntaxNode) -> Option<HashMap<String, Var
                             );
                         }
                     }
+                    if let Some(ident) = pattern.at() {
+                        if !scope.contains_key(ident.as_str()) {
+                            scope.insert(
+                                ident.as_str().into(),
+                                Var {
+                                    file: Rc::clone(&file),
+                                    set: lambda.node().to_owned(),
+                                    key: ident.node().to_owned(),
+                                    value: None,
+                                    datatype: Datatype::Lambda,
+                                },
+                            );
+                        }
+                    }
                 }
                 _ => (),
             },


### PR DESCRIPTION
__Note:__ this is based on the `bump-rnix` branch and shouldn't be merged until that is merged to master.
cc @jD91mZM2 