### PR TITLE
Enhance completion details for builtins if Nix 2.4 is available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "lsp-server",
  "lsp-types",
  "nixpkgs-fmt",
+ "regex",
  "rnix",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rnix = "0.9.0"
 serde = "1.0.104"
 serde_json = "1.0.44"
 lazy_static = "1.4"
+regex = "1"
 
 [patch.crates-io]
 nixpkgs-fmt = { git = "https://github.com/jD91mZM2/nixpkgs-fmt", branch = "bump-rnix" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,7 +246,7 @@ impl App {
         let (name, scope, _) = self.scope_for_ident(params.text_document.uri, &node, offset)?;
 
         let var_e = scope.get(name.as_str())?;
-        if let (_, Some(var)) = var_e {
+        if let Some(var) = &var_e.var {
             let (_definition_ast, definition_content) = self.files.get(&var.file)?;
             Some(Location {
                 uri: (*var.file).clone(),
@@ -269,15 +269,18 @@ impl App {
         let (_, content) = self.files.get(&params.text_document.uri)?;
 
         let mut completions = Vec::new();
-        for (var, (datatype, _)) in scope {
+        for (var, data) in scope {
             if var.starts_with(&name.as_str()) {
+                let det = data.render_detail();
                 completions.push(CompletionItem {
                     label: var.clone(),
+                    documentation: data.documentation.map(|x| lsp_types::Documentation::String(x)),
+                    deprecated: Some(data.deprecated),
                     text_edit: Some(TextEdit {
                         range: utils::range(content, node.node().text_range()),
                         new_text: var.clone(),
                     }),
-                    detail: Some(datatype.to_string()),
+                    detail: Some(det),
                     ..CompletionItem::default()
                 });
             }


### PR DESCRIPTION
__Note:__ this isn't completed ready yet:

* [ ] There are a bit too many `.unwrap()`-calls where better handling may be useful if e.g. the format of `nix __dump-builtins` changes in the future.
* [ ] I didn't test this very thoroughly. I guess I'll use this for a bit in my neovim setup to check if I encounter any issues.

-----



A hidden feature of Nix 2.4+ (a.k.a. `nixUnstable`) is `nix
__dump-builtins` which returns a JSON giving details about built in
functions.

This change basically does the following things:

* It checks whether Nix 2.4 is available on `$PATH`[1]. In that case
  built-in functions are retrieved via `nix __dump-builtins`[2].

  If not, the hard-coded list of builtins is used as a fallback.

* If builtins can be retrieved from Nix, the following additional things
  are added to `CompletionItem`:

  * The `documentation`[3] field containing markdown documentation for the
    function is added. This will be shown in editors as one is used to
    it from e.g. doc-block comments in other languages.

  * A very basic parameter info is provided. E.g. for
    `builtins.removeAttrs` the popup shows `Lambda: set -> list ->
    Result`. While this is fairly basic, it's IMHO a small benefit to
    make sure one's not forgetting the order of parameters.

    Please note that this will currently display *wrong* info if
    a built-in is called via `lib.flip`.

  * If `**DEPRECATED.**` is at the beginning of `documentation`, the
    built-in is marked in the LSP response as `deprecated`. While this
    is a gross hack, it ensures that the only deprecated builtin
    (`builtins.toPath`) is actually marked as such.

[1] Please note that this means that you can wrap `$PATH` for `rnix-lsp`
    to have this feature without being forced to use `nixUnstable` on
    your system.
[2] As this is only an optional feature (and hence a loose dependency to
    Nix) I decided against using an FFI and thus keeping the build
    process rather simple.
[3] https://microsoft.github.io/language-server-protocol/specification#textDocument_completion


-----

cc @jD91mZM2 