### PR TITLE
Fix bogus syntax errors in Nix expressions containing multi-byte characters

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -253,7 +253,12 @@ impl App {
                         }
                     };
 
-                    let mut newline_iter = content.match_indices('\n');
+                    let content_utf16 = content.encode_utf16().collect::<Vec<_>>();
+                    let ascii_newline = 10;
+                    let mut newline_iter = content_utf16
+                        .iter()
+                        .enumerate()
+                        .filter(|&(_, x)| *x == ascii_newline);
 
                     let start_idx = if range.start.line == 0 {
                         0
@@ -271,7 +276,6 @@ impl App {
                     };
 
                     // Language server ranges are based on UTF-16 (https://git.io/JcrUi)
-                    let content_utf16 = content.encode_utf16().collect::<Vec<_>>();
                     let mut new_content = String::from_utf16_lossy(&content_utf16[..start_idx]);
                     new_content.push_str(&change.text);
                     let suffix = String::from_utf16_lossy(&content_utf16[end_idx..]);


### PR DESCRIPTION
In a few files I got some syntax errors when modifying their contents.
An example is `<nixpkgs/lib/generators.nix>`[1] with the following
contents in the multi-line comment at the top:

> [...]
> * `config-attrs` are “holes” in the generators
> [...]

These multi-byte quotes confuse the LSP because the LSP itself doesn't
care about the byte offsets itself, but provides character positions in
incremental updates[2]. To quote the specification:

> So a string of the form a𐐀b the character offset of the character a is 0,
> the character offset of 𐐀 is 1 and the character offset of b is 3 since 𐐀 is
> represented using two code units in UTF-16.

However, the actual length (in bytes) of the UTF-16 character from above is
`4`, so a byte-aware offset would be wrong. Unfortunately, `match_indices()`
doesn't work on a character-level, but on a byte-level:

    >> "”\n".match_indices('\n').collect::<Vec<_>>()
    [(3, "\n")]
    >> "x\n".match_indices('\n').collect::<Vec<_>>()
    [(1, "\n")]

This shows that the offset of a newline behind a multi-byte character is
actually wrong and thus the "final" offset in the file is at a different
position than the offset provided by the LSP which often causes syntax
errors when parsing the new expression.

To work around this, I implemented an alternative version of
`.match_indices()` which filters through the UTF-16 codes of the change
and creates tuples with offsets whenever a character matches `10` (the
ASCII and UTF-* code of '\n').

[1] https://github.com/NixOS/nixpkgs/blob/6cc260cfd60f094500b79e279069b499806bf6d8/lib/generators.nix
[2] https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocuments