### PR TITLE
Cleanup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,11 @@
-use flake
+{
+# shell gc root dir
+mkdir -p $(direnv_layout_dir)
+
+# reload when these files change
+watch_file flake.nix
+watch_file flake.lock
+
+# load the flake devShell
+eval "$(nix print-dev-env --impure --profile $(direnv_layout_dir)/flake-profile)"
+} || use nix

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ rnix = "0.9.0"
 rowan = "0.12.6"
 serde = "1.0.104"
 serde_json = "1.0.44"
+
+[profile.release]
+lto = true

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1629707199,
-        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
+        "lastModified": 1631004250,
+        "narHash": "sha256-LGh0CjAZwh13AVkTi9w9lITEC7x6bwSQyFViOZ6HyNo=",
         "owner": "nmattia",
         "repo": "naersk",
-        "rev": "df71f5e4babda41cd919a8684b72218e2e809fa9",
+        "rev": "08afb3d1dbfe016108b72e05b02ba0f6ecb3c8e1",
         "type": "github"
       },
       "original": {
@@ -22,16 +22,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1630481079,
-        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
+        "lastModified": 1631315520,
+        "narHash": "sha256-Y8j0JYtZMifrHaWdTfTp1mYVXZ2PLJO/P0XZxMvo7KU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
+        "rev": "b72ad04a8a324697d3fb92e19cd840379a902813",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-21.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     naersk.url = "github:nmattia/naersk";
     utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     naersk.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -24,9 +24,14 @@
         defaultPackage = packages.rnix-lsp;
 
         devShell = pkgs.mkShell {
+          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+
           nativeBuildInputs = with pkgs; [
             rustc
             cargo
+            clippy
+            rust-analyzer
+            rustfmt
             gitAndTools.pre-commit
           ];
         };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,10 @@
-use lsp_types::*;
-use rnix::{types::*, SyntaxNode, TextRange, TextSize, TokenAtOffset};
+use lsp_types::{Position, Range, SelectionRange, Url};
+use rnix::{
+    types::{
+        EntryHolder, Ident, Inherit, Key, ParsedType, Select, TokenWrapper, TypedNode, Wrapper,
+    },
+    SyntaxNode, TextRange, TextSize, TokenAtOffset,
+};
 use std::{
     collections::HashMap,
     convert::TryFrom,
@@ -128,22 +133,17 @@ pub fn ident_at(root: &SyntaxNode, offset: usize) -> Option<CursorInfo> {
     if let Some(node) = parent.clone().and_then(Inherit::cast) {
         if let Some(node) = node.from() {
             if let Some(tok) = node.inner() {
-                if let Some(_) = Ident::cast(tok.clone()) {
-                    return Some(CursorInfo::new(
-                        vec![tok.text().to_string()],
-                        ident.clone(),
-                        None,
-                    ));
-                } else if let Some(mut attr) = Select::cast(tok.clone()) {
-                    let mut result = Vec::new();
-                    result.push(attr.index()?.to_string().into());
+                if Ident::cast(tok.clone()).is_some() {
+                    return Some(CursorInfo::new(vec![tok.text().to_string()], ident, None));
+                } else if let Some(mut attr) = Select::cast(tok) {
+                    let mut result = vec![attr.index()?.to_string()];
                     while let Some(new) = Select::cast(attr.set()?) {
                         result.push(Ident::cast(new.index()?)?.as_str().into());
                         attr = new;
                     }
                     result.push(Ident::cast(attr.set()?)?.as_str().into());
                     result.reverse();
-                    return Some(CursorInfo::new(result, ident.clone(), None));
+                    return Some(CursorInfo::new(result, ident, None));
                 }
             }
         }
@@ -178,10 +178,7 @@ pub fn ident_at(root: &SyntaxNode, offset: usize) -> Option<CursorInfo> {
         Some(CursorInfo::new(
             path,
             ident,
-            match add {
-                true => Some(String::from("")),
-                false => None,
-            },
+            if add { Some(String::from("")) } else { None },
         ))
     } else {
         Some(CursorInfo::new(Vec::new(), ident, None))
@@ -211,10 +208,10 @@ pub fn populate<T: EntryHolder>(
                     ident.as_str().into(),
                     Var {
                         file: Rc::clone(file),
-                        set: set.node().to_owned(),
-                        key: ident.node().to_owned(),
-                        value: Some(entry.value()?.to_owned()),
-                        datatype: datatype,
+                        set: set.node().clone(),
+                        key: ident.node().clone(),
+                        value: Some(entry.value()?.clone()),
+                        datatype,
                     },
                 );
             }
@@ -229,14 +226,14 @@ pub fn scope_for(file: &Rc<Url>, node: SyntaxNode) -> Option<HashMap<String, Var
     while let Some(node) = current {
         match ParsedType::try_from(node.clone()) {
             Ok(ParsedType::LetIn(let_in)) => {
-                populate(&file, &mut scope, &let_in, Datatype::Variable);
+                populate(file, &mut scope, &let_in, Datatype::Variable);
             }
             Ok(ParsedType::LegacyLet(let_)) => {
-                populate(&file, &mut scope, &let_, Datatype::Variable);
+                populate(file, &mut scope, &let_, Datatype::Variable);
             }
             Ok(ParsedType::AttrSet(set)) => {
                 if set.recursive() {
-                    populate(&file, &mut scope, &set, Datatype::Attribute);
+                    populate(file, &mut scope, &set, Datatype::Attribute);
                 }
             }
             Ok(ParsedType::Lambda(lambda)) => match ParsedType::try_from(lambda.arg()?) {
@@ -245,7 +242,7 @@ pub fn scope_for(file: &Rc<Url>, node: SyntaxNode) -> Option<HashMap<String, Var
                         scope.insert(
                             ident.as_str().into(),
                             Var {
-                                file: Rc::clone(&file),
+                                file: Rc::clone(file),
                                 set: lambda.node().clone(),
                                 key: ident.node().clone(),
                                 value: None,
@@ -261,9 +258,9 @@ pub fn scope_for(file: &Rc<Url>, node: SyntaxNode) -> Option<HashMap<String, Var
                             scope.insert(
                                 ident.as_str().into(),
                                 Var {
-                                    file: Rc::clone(&file),
-                                    set: lambda.node().to_owned(),
-                                    key: ident.node().to_owned(),
+                                    file: Rc::clone(file),
+                                    set: lambda.node().clone(),
+                                    key: ident.node().clone(),
                                     value: None,
                                     datatype: Datatype::Lambda,
                                 },
@@ -275,9 +272,9 @@ pub fn scope_for(file: &Rc<Url>, node: SyntaxNode) -> Option<HashMap<String, Var
                             scope.insert(
                                 ident.as_str().into(),
                                 Var {
-                                    file: Rc::clone(&file),
-                                    set: lambda.node().to_owned(),
-                                    key: ident.node().to_owned(),
+                                    file: Rc::clone(file),
+                                    set: lambda.node().clone(),
+                                    key: ident.node().clone(),
                                     value: None,
                                     datatype: Datatype::Lambda,
                                 },
@@ -336,10 +333,7 @@ mod tests {
         assert_eq!(0, start.start.character);
         assert_eq!(1, start.end.character);
 
-        let actual_pos = range(expr, TextRange::new(
-            TextSize::from(15),
-            TextSize::from(20)
-        ));
+        let actual_pos = range(expr, TextRange::new(TextSize::from(15), TextSize::from(20)));
 
         assert_eq!(1, actual_pos.start.line);
         assert_eq!(1, actual_pos.end.line);
@@ -368,10 +362,13 @@ mod tests {
     #[test]
     fn test_lookup_pos_in_expr() {
         let expr = "let a = 1;\nbuiltins.trace a 23";
-        let pos = lookup_pos(expr, Position {
-            line: 0,
-            character: 0,
-        });
+        let pos = lookup_pos(
+            expr,
+            Position {
+                line: 0,
+                character: 0,
+            },
+        );
 
         assert_eq!(0, pos.expect("expected position to be not None!"));
     }
@@ -379,17 +376,29 @@ mod tests {
     #[test]
     fn test_lookup_pos_out_of_range() {
         let expr = "let a = 1;\na";
-        let pos_wrong_line = lookup_pos(expr, Position {
-            line: 5,
-            character: 23,
-        });
+        let pos_wrong_line = lookup_pos(
+            expr,
+            Position {
+                line: 5,
+                character: 23,
+            },
+        );
 
         assert!(pos_wrong_line.is_none());
 
         // if the character is greater than the length of a line, the offset of the last
         // char of the line is returned.
-        let pos_char_out_of_range = lookup_pos(expr, Position { line: 0, character: 100, });
-        assert_eq!(10, pos_char_out_of_range.expect("expected position to be not None!"));
+        let pos_char_out_of_range = lookup_pos(
+            expr,
+            Position {
+                line: 0,
+                character: 100,
+            },
+        );
+        assert_eq!(
+            10,
+            pos_char_out_of_range.expect("expected position to be not None!")
+        );
     }
 
     #[test]
@@ -398,21 +407,26 @@ mod tests {
         let root = rnix::parse(expr).node();
         let scope = scope_for(
             &Rc::new(Url::parse("file:///default.nix").unwrap()),
-            root.children().next().unwrap()
+            root.children().next().unwrap(),
         );
 
         assert!(scope.is_some());
         let scope_entries = scope.unwrap();
 
         assert_eq!(5, scope_entries.keys().len());
-        assert!(scope_entries.values().into_iter().all(|x| x.datatype == Datatype::Lambda));
-        assert!(vec!["n", "a", "b", "c", "d"].into_iter().all(|x| scope_entries.contains_key(x)));
+        assert!(scope_entries
+            .values()
+            .into_iter()
+            .all(|x| x.datatype == Datatype::Lambda));
+        assert!(vec!["n", "a", "b", "c", "d"]
+            .into_iter()
+            .all(|x| scope_entries.contains_key(x)));
 
         let mut iter = root.children().next().unwrap().children();
         iter.next();
         let scope_let = scope_for(
             &Rc::new(Url::parse("file:///default.nix").unwrap()),
-            iter.next().unwrap()
+            iter.next().unwrap(),
         );
 
         assert!(scope_let.is_some());
@@ -427,14 +441,16 @@ mod tests {
         let root = rnix::parse(expr).node();
         let scope = scope_for(
             &Rc::new(Url::parse("file:///default.nix").unwrap()),
-            root.children().next().unwrap()
+            root.children().next().unwrap(),
         );
 
         assert!(scope.is_some());
         let scope_entries = scope.unwrap();
 
         assert_eq!(2, scope_entries.keys().len());
-        assert!(vec!["a", "body"].into_iter().all(|x| scope_entries.contains_key(x)));
+        assert!(vec!["a", "body"]
+            .into_iter()
+            .all(|x| scope_entries.contains_key(x)));
     }
 
     #[test]


### PR DESCRIPTION
The biggest change here is the cleansing of all outstanding clippy lint warnings. I had to add an exception for     `clippy::cast_possible_truncation` as the `lsp_types::Position` struct requires a u32, but we are currently building it from a usize.

I also ran a `cargo fmt` on the codebase, removed the implicit nix-direnv dependency on the envrc, added some rust development tools to the devshell and pulled rust from unstable to get a slightly newer version.

[One of the lints](https://github.com/nix-community/rnix-lsp/pull/52/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL151) corrected a scenario where a value's `Drop` destructor was never called, so there may be a miniscule chance that this was the root cause of #33.