### PR TITLE
Enhance testsuite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "rowan",
  "serde",
  "serde_json",
+ "stoppable_thread",
 ]
 
 [[package]]
@@ -553,6 +554,12 @@ name = "smol_str"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b203e79e90905594272c1c97c7af701533d42adaab0beb3859018e477d54a3b0"
+
+[[package]]
+name = "stoppable_thread"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6700c1ed393aa9c1fff950032a64a4856436dadee820641ce1b914cab65019f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ rnix = "0.9.1"
 rowan = "0.12.6"
 serde = "1.0.104"
 serde_json = "1.0.44"
+
+[dev-dependencies]
+stoppable_thread = "0.2"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,6 +5,13 @@ use scope::Scope;
 use std::borrow::Borrow;
 use value::NixValue;
 
+#[cfg(test)]
+use serde_json::json;
+#[cfg(test)]
+use std::time::Duration;
+#[cfg(test)]
+use stoppable_thread::*;
+
 #[allow(dead_code)]
 fn eval(code: &str) -> NixValue {
     let ast = rnix::parse(&code);
@@ -40,4 +47,97 @@ fn order_of_operations() {
 fn div_int_by_float() {
     let code = "1 / 2.0";
     assert_eq!(eval(code).as_float().unwrap(), 0.5);
+}
+
+#[cfg(test)]
+fn prepare_integration_test(code: &str, filename: &str) -> (Connection, StoppableHandle<()>) {
+    let (server, client) = Connection::memory();
+
+    // Manually handle LSP communications here. This is needed in order to not wait
+    // indefinetely for a message to be able to exit as soon as the test is finished
+    // and the thread is stopped.
+    let h = spawn(move |stopped| {
+        let mut app = App { files: HashMap::new(), conn: server };
+
+        loop {
+            if let Ok(msg) = app.conn.receiver.recv_timeout(Duration::from_millis(100)) {
+                match msg {
+                    Message::Request(req) => app.handle_request(req),
+                    Message::Notification(notification) => {
+                        let _ = app.handle_notification(notification);
+                    }
+                    Message::Response(_) => (),
+                }
+            }
+            if stopped.get() {
+                break;
+            }
+        }
+    });
+
+    let open = Notification {
+        method: String::from("textDocument/didOpen"),
+        params: json!({
+            "textDocument": { "uri": filename, "text": code, "version": 1, "languageId": "nix" }
+        })
+    };
+    client.sender.send(open.into()).expect("Cannot send didOpen!");
+
+    (client, h)
+}
+
+#[cfg(test)]
+fn recv_msg(client: &Connection) -> lsp_server::Message {
+    client.receiver.recv_timeout(Duration::new(5, 0)).expect("No message within 5 secs!")
+}
+
+#[cfg(test)]
+fn expect_diagnostics(client: &Connection) {
+    let notf = recv_msg(client);
+    if let Message::Notification(x) = notf {
+        assert_eq!("textDocument/publishDiagnostics", x.method);
+    } else {
+        panic!("Expected diagnostics notification!");
+    }
+}
+
+#[cfg(test)]
+fn coerce_response(msg: lsp_server::Message) -> lsp_server::Response {
+    if let Message::Response(x) = msg {
+        x
+    } else {
+        panic!("Expected LSP message to be a response!");
+    }
+}
+
+#[test]
+fn test_hover_integration() {
+    // Since we transmit content via `textDocument/didOpen`, we can
+    // use made-up names for paths here that don't need to exist anywhere.
+    let urlpath = "file:///code/default.nix";
+    let (client, handle) = prepare_integration_test("(1 + 1)", urlpath);
+
+    let r = Request {
+        id: RequestId::from(23),
+        method: String::from("textDocument/hover"),
+        params: json!({
+            "textDocument": {
+                "uri": "file:///code/default.nix",
+            },
+            "position": {
+                "line": 0,
+                "character": 7
+            }
+        })
+    };
+    client.sender.send(r.into()).expect("Cannot send hover notification!");
+
+    expect_diagnostics(&client);
+
+    let msg = recv_msg(&client);
+    let hover_json = coerce_response(msg).result.expect("Expected hover response!");
+    let hover_value = &hover_json.as_object().unwrap()["contents"]["value"];
+    assert_eq!("2", *hover_value.to_string().split("\\n").collect::<Vec<_>>().get(1).unwrap());
+
+    handle.stop().join().expect("Failed to gracefully terminate LSP worker thread!");
 }


### PR DESCRIPTION
* Add testcase for scope-imports in `lookup.rs`. From my PoV this will remain relevant with the evaluator since the underlying logic (navigating through the AST to find actual scopes).
* Added some integration tests + some structure to easily implement more.