### PR TITLE
GHA: add `-L` to `nix build`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v14
-    - run: nix build -f . -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz --show-trace
+    - run: nix build -L -f . -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz --show-trace


### PR DESCRIPTION
With this we're seeing more information on why something broke.