### PR TITLE
add autocomplete via evaluation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,7 @@ default = []
 # This can be helpful for debugging, but we don't want the evaluator to
 # spam users when confused, so this is disabled by default.
 verbose = []
+
+# # Helpful for trying different rnix-parser versions
+# [patch.crates-io]
+# rnix = { path = "../rnix-parser" }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -74,6 +74,19 @@ impl Scope {
         }
     }
 
+    /// List all variable names in a given scope
+    pub fn list(&self) -> Vec<String> {
+        match self {
+            Scope::None => vec![],
+            Scope::Root(..) => vec![],
+            Scope::Let { parent, contents } => {
+                let mut out: Vec<String> = contents.borrow().keys().cloned().collect();
+                out.extend(parent.list());
+                out
+            }
+        }
+    }
+
     pub fn root_path(&self) -> Option<PathBuf> {
         match &self {
             Scope::None => None,


### PR DESCRIPTION
<!--
Feel free to remove paragraphs that don't apply to your PR.
-->

### Summary & Motivation

This allows users to auto-complete based on evaluation. This is especially helpful for selecting from attribute sets.

This PR prioritizes existing static analysis completions over completions provided by the evaluator, since existing functionality is known to work well.

Auto-complete for the evaluator shows up immediately after pressing the period key. This does not work for the static `builtins`. I looked into changing that, but I think it would require enough effort to warrant a separate (but still small) PR.

### Further context

This depends upon graceful error handling in rnix-parser. I've been testing this PR with https://github.com/nix-community/rnix-parser/pull/34 (see the comments this PR adds to the `Cargo.toml` for details on patching rnix-parser while developing).

<!--
If applicable, please give further context such as related issues / PRs,
an explanation of the problem you're aiming to solve or anything else you also
consider relevant.
-->
