### PR TITLE
enable tooling within lambda bodies

### DIFF
--- a/playground/lambda.nix
+++ b/playground/lambda.nix
@@ -1,0 +1,8 @@
+{ hello }:
+
+rec {
+    foo.bar = 13;
+    xyz = foo;
+    bbb = hello;
+    abc = xyz.bar;
+}.xyz.bar

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -46,6 +46,9 @@ impl Expr {
         let recurse_box = |node| Expr::parse(node, scope.clone()).map(|x| Box::new(x));
         let recurse_gc = |node| Expr::parse(node, scope.clone()).map(|x| Gc::new(x));
         let source = match ParsedType::try_from(node.clone()).map_err(|_| ERR_PARSING)? {
+            ParsedType::Lambda(lambda) => ExprSource::Lambda {
+                body: recurse_box(lambda.body().ok_or(ERR_PARSING)?),
+            },
             ParsedType::Select(select) => ExprSource::Select {
                 from: recurse_gc(select.set().ok_or(ERR_PARSING)?),
                 index: recurse_box(select.index().ok_or(ERR_PARSING)?),


### PR DESCRIPTION
This minimally implements parsing of lambdas, just enough to allow `climb_expr` to look inside a lambda's body. Although the evaluator in this PR doesn't understand lambda arguments, existing fallback to static analysis still allows goto-definition for arguments.

Because many Nix files are lambdas, this PR will significantly increase the number of files that evaluation tooling will be work on.

For example:
```nix
{ hello }:

# basic tooling now works here
rec {
    foo.bar = 13;
    xyz = foo;
    bbb = hello;
    abc = xyz.bar;
}.xyz.bar
```
