### PR TITLE
remove leading newline from attr set's fmt::Display

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -120,7 +120,7 @@ impl Display for NixValue {
                 if map.keys().len() > MAX_DISPLAY_KEYS {
                     body.push_str(", ...");
                 }
-                write!(f, "\n{{ {} }}", body)
+                write!(f, "{{ {} }}", body)
             }
         }
     }


### PR DESCRIPTION
Currently, attribute sets are formatted with a trailing newline (in addition to the one added in [`format_markdown`](https://github.com/nix-community/rnix-lsp/blob/9462b0d20325a06f7e43b5a0469ec2c92e60f5fe/src/value.rs#L84)).

This adds an unnecessary blank line to the hover preview, which looks strange and is inconsistent with how other types are displayed.

This bug was introduced by me in #55. 