### PR TITLE
Bump `rnix` to `0.10.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,8 +353,7 @@ dependencies = [
 [[package]]
 name = "nixpkgs-fmt"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a82272a0eee2fef69a1af311f01ff84edac1f4f1680095b9a86f409cf00bd00"
+source = "git+git://github.com/ma27/nixpkgs-fmt?tag=v1.2.0-rnix-0.10#2b4e9a3ab49ce9fd3e0e09f3b32a2bfb92b395f6"
 dependencies = [
  "clap",
  "crossbeam-channel 0.3.9",
@@ -442,9 +441,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rnix"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294becb48f58c496d96c10a12df290266204ca75c9799be4d04222bfaebb6a37"
+checksum = "065c5eac8e8f7e7b0e7227bdc46e2d8dd7d69fff7a9a2734e21f686bbcb9b2c9"
 dependencies = [
  "cbitset",
  "rowan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,15 @@ libc = "0.2.66"
 log = "0.4.8"
 lsp-server = "0.5.2"
 lsp-types = { version = "0.89.2", features = ["proposed"] }
-nixpkgs-fmt = "1.2.0"
 regex = "1"
-rnix = "0.9.1"
+rnix = "0.10.1"
 rowan = "0.12.6"
 serde = "1.0.104"
 serde_json = "1.0.44"
+
+[dependencies.nixpkgs-fmt]
+git = "git://github.com/ma27/nixpkgs-fmt"
+tag = "v1.2.0-rnix-0.10"
 
 [dev-dependencies]
 stoppable_thread = "0.2"

--- a/flake.lock
+++ b/flake.lock
@@ -7,15 +7,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1629707199,
-        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
-        "owner": "nmattia",
+        "lastModified": 1639947939,
+        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
+        "owner": "nix-community",
         "repo": "naersk",
-        "rev": "df71f5e4babda41cd919a8684b72218e2e809fa9",
+        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
         "type": "github"
       },
       "original": {
-        "owner": "nmattia",
+        "owner": "nix-community",
         "repo": "naersk",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A work-in-progress language server for Nix, with syntax checking and basic completion";
 
   inputs = {
-    naersk.url = "github:nmattia/naersk";
+    naersk.url = "github:nix-community/naersk";
     utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-21.05";
     naersk.inputs.nixpkgs.follows = "nixpkgs";

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -273,7 +273,7 @@ impl Expr {
                         }
                     };
                 }
-                match binop.operator() {
+                match binop.operator().unwrap() {
                     And => ExprSource::BoolAnd { left, right },
                     Or => ExprSource::BoolOr { left, right },
                     Implication => ExprSource::Implication { left, right },


### PR DESCRIPTION
### Summary & Motivation

* Updated the `rnix` dependency to 0.10.1 & fixed compilation errors.
* Updated `nixpkgs-fmt` to a tag `v1.2.0-rnix-0.10`[1]. I explicitly
  decided against using `master` as the formatting results are slightly
  different to the results of v1.2.0 and we should remain consistent to
  what `pkgs.nixpkgs-fmt` would do.
* Switched to a custom fork of `naersk` to keep the build evaluating[2].

[1] https://github.com/Ma27/nixpkgs-fmt/releases/tag/v1.2.0-rnix-0.10
[2] https://github.com/nix-community/naersk/pull/219

### Further context

I'd cherry-pick this commit on top of `0.2.1` and then publish `0.2.2` to get Nix 2.4 support out.