### PR TITLE
improve command copying from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Support for **Mac OS** is not guaranteed (see [PR #61](https://github.com/nix-co
 ## Install
 
 ```
-$ nix-env -i -f https://github.com/nix-community/rnix-lsp/archive/master.tar.gz
+nix-env -i -f https://github.com/nix-community/rnix-lsp/archive/master.tar.gz
 ```
 
 ## Integrate with your editor


### PR DESCRIPTION

### Summary & Motivation

This PR removes the `$` prompt symbol from the installation snippet. Now the snippet can be copied and used as-is.



<!--
If applicable, please give further context such as related issues / PRs,
an explanation of the problem you're aiming to solve or anything else you also
consider relevant.
-->
