### PR TITLE
flake: Bump `nixpkgs` & `flake-utils`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,16 +22,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1630481079,
-        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
+        "lastModified": 1642190797,
+        "narHash": "sha256-cxeEEAtfIACnm8sV1oz0xlNp9IVk10Fxcc09ggoEZuo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
+        "rev": "3ddd960a3b575bf3230d0e59f42614b71f9e0db9",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-21.05",
+        "ref": "nixos-21.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -45,11 +45,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1629481132,
-        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     naersk.url = "github:nix-community/naersk";
     utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
     naersk.inputs.nixpkgs.follows = "nixpkgs";
   };
 
@@ -19,7 +19,7 @@
           pname = "rnix-lsp";
           root = ./.;
           doCheck = true;
-          checkInputs = [ pkgs.nixUnstable ];
+          checkInputs = [ pkgs.nix_2_4 ];
         };
         defaultPackage = packages.rnix-lsp;
 

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -296,6 +296,10 @@ mod tests {
     }
 
     #[test]
+    // FIXME re-activate it again for macos as soon as
+    // https://github.com/NixOS/nix/issues/5884 / https://github.com/nix-community/rnix-lsp/issues/75
+    // is properly resolved
+    #[cfg_attr(target_os = "macos", ignore)]
     fn test_provide_builtins() {
         let root = rnix::parse("builtins.map (y: y)").node();
         let mut app = App {


### PR DESCRIPTION
### Summary & Motivation

Bump `nixpkgs` to 21.11 since 21.05 is dead. Also, the `nixUnstable` from 21.05 doesn't seem to build on Darwin.

### Further context

see #71 
cc @DieracDelta 
