### PR TITLE
Apply compiler hints

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,6 @@ use gc::{Finalize, Trace};
 
 pub const ERR_PARSING: EvalError = EvalError::Internal(InternalError::Parsing);
 
-
 #[derive(Debug, Clone, Trace, Finalize)]
 pub enum EvalError {
     Internal(InternalError),
@@ -69,7 +68,9 @@ impl std::fmt::Display for ValueError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             ValueError::DivisionByZero => write!(f, "division by zero"),
-            ValueError::AttrAlreadyDefined(name) => write!(f, "attribute `{}` defined more than once", name),
+            ValueError::AttrAlreadyDefined(name) => {
+                write!(f, "attribute `{}` defined more than once", name)
+            }
             ValueError::TypeError(msg) => write!(f, "{}", msg),
         }
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -119,7 +119,7 @@ impl Expr {
                 // from an .eval(), which is probably infinite recursion.
                 return Err(EvalError::Internal(InternalError::Unimplemented(
                     "infinite recursion".to_string(),
-                )))
+                )));
             }
         };
         if let Some(ref value) = *value_borrow {
@@ -285,9 +285,7 @@ impl Expr {
             ExprSource::Implication { left, right } => vec![left, right],
             ExprSource::UnaryInvert { value } => vec![value],
             ExprSource::UnaryNegate { value } => vec![value],
-            ExprSource::AttrSet {
-                definitions,
-            } => {
+            ExprSource::AttrSet { definitions } => {
                 let mut out = vec![];
                 out.extend(definitions);
                 // This looks similar to code at the end of the function, but
@@ -402,7 +400,9 @@ pub fn merge_set_literal(name: String, a: Gc<Expr>, b: Gc<Expr>) -> Result<Gc<Ex
             // ```
             // The above would be caught because `x` is an ExprSource::Ident (as
             // opposed to being an ExprSource::AttrSet literal).
-            Err(EvalError::Value(ValueError::AttrAlreadyDefined(name.to_string())))
+            Err(EvalError::Value(ValueError::AttrAlreadyDefined(
+                name.to_string(),
+            )))
         }
     };
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -247,10 +247,12 @@ impl Expr {
                 .get(name)
                 // We don't have everything implemented yet, so silently fail,
                 // assuming we're at fault
-                .ok_or(EvalError::Internal(InternalError::Unimplemented(format!(
-                    "not found in scope: {}",
-                    name
-                ))))?
+                .ok_or_else(|| {
+                    EvalError::Internal(InternalError::Unimplemented(format!(
+                        "not found in scope: {}",
+                        name
+                    )))
+                })?
                 .eval(),
             ExprSource::Select { from, index } => {
                 let key = index.as_ref()?.as_ident()?;
@@ -338,7 +340,7 @@ impl Expr {
     pub fn get_definition(&self) -> Option<Gc<Expr>> {
         use ExprSource::*;
         match &self.source {
-            Ident { name } => self.scope.get(&name),
+            Ident { name } => self.scope.get(name),
             Select { from, index } => {
                 let idx = index.as_ref().ok()?.as_ident().ok()?;
                 let out = from

--- a/src/main.rs
+++ b/src/main.rs
@@ -352,7 +352,7 @@ impl App {
         let start: usize = range.start().into();
         let end: usize = range.end().into();
         if start <= offset && offset < end {
-            return None
+            return None;
         }
 
         let (_definition_ast, definition_content, _) = self.files.get(&var.file)?;
@@ -377,7 +377,7 @@ impl App {
         let start: usize = range.start().into();
         let end: usize = range.end().into();
         if start <= offset && offset < end {
-            return None
+            return None;
         }
 
         let def_path = def.scope.root_path()?;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -211,7 +211,9 @@ impl Expr {
                             let name = name.to_string();
                             match value_map.entry(name.clone()) {
                                 Entry::Occupied(_) => {
-                                    return Err(EvalError::Value(ValueError::AttrAlreadyDefined(name)))
+                                    return Err(EvalError::Value(ValueError::AttrAlreadyDefined(
+                                        name,
+                                    )))
                                 }
                                 Entry::Vacant(entry) => entry.insert(attr),
                             };
@@ -232,7 +234,9 @@ impl Expr {
                             let name = name.to_string();
                             match value_map.entry(name.clone()) {
                                 Entry::Occupied(_) => {
-                                    return Err(EvalError::Value(ValueError::AttrAlreadyDefined(name)))
+                                    return Err(EvalError::Value(ValueError::AttrAlreadyDefined(
+                                        name,
+                                    )))
                                 }
                                 Entry::Vacant(entry) => entry.insert(attr),
                             };

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -43,9 +43,9 @@ impl Expr {
     /// rnix::SyntaxNode isn't recognized, we don't get tooling for its children.
     pub fn parse(node: SyntaxNode, scope: Gc<Scope>) -> Result<Self, EvalError> {
         let range = Some(node.text_range());
-        let recurse_box = |node| Expr::parse(node, scope.clone()).map(|x| Box::new(x));
-        let recurse_gc = |node| Expr::parse(node, scope.clone()).map(|x| Gc::new(x));
-        let source = match ParsedType::try_from(node.clone()).map_err(|_| ERR_PARSING)? {
+        let recurse_box = |node| Expr::parse(node, scope.clone()).map(Box::new);
+        let recurse_gc = |node| Expr::parse(node, scope.clone()).map(Gc::new);
+        let source = match ParsedType::try_from(node).map_err(|_| ERR_PARSING)? {
             ParsedType::Select(select) => ExprSource::Select {
                 from: recurse_gc(select.set().ok_or(ERR_PARSING)?),
                 index: recurse_box(select.index().ok_or(ERR_PARSING)?),
@@ -146,7 +146,7 @@ impl Expr {
                                 key: element,
                                 value: Ok(tmp_attr_set),
                             },
-                            range: Some(cursor_range.clone()),
+                            range: Some(cursor_range),
                             scope: new_scope.clone(),
                         });
                     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -57,7 +57,10 @@ fn prepare_integration_test(code: &str, filename: &str) -> (Connection, Stoppabl
     // indefinetely for a message to be able to exit as soon as the test is finished
     // and the thread is stopped.
     let h = spawn(move |stopped| {
-        let mut app = App { files: HashMap::new(), conn: server };
+        let mut app = App {
+            files: HashMap::new(),
+            conn: server,
+        };
 
         loop {
             if let Ok(msg) = app.conn.receiver.recv_timeout(Duration::from_millis(100)) {
@@ -79,16 +82,22 @@ fn prepare_integration_test(code: &str, filename: &str) -> (Connection, Stoppabl
         method: String::from("textDocument/didOpen"),
         params: json!({
             "textDocument": { "uri": filename, "text": code, "version": 1, "languageId": "nix" }
-        })
+        }),
     };
-    client.sender.send(open.into()).expect("Cannot send didOpen!");
+    client
+        .sender
+        .send(open.into())
+        .expect("Cannot send didOpen!");
 
     (client, h)
 }
 
 #[cfg(test)]
 fn recv_msg(client: &Connection) -> lsp_server::Message {
-    client.receiver.recv_timeout(Duration::new(5, 0)).expect("No message within 5 secs!")
+    client
+        .receiver
+        .recv_timeout(Duration::new(5, 0))
+        .expect("No message within 5 secs!")
 }
 
 #[cfg(test)]
@@ -128,18 +137,34 @@ fn test_hover_integration() {
                 "line": 0,
                 "character": 7
             }
-        })
+        }),
     };
-    client.sender.send(r.into()).expect("Cannot send hover notification!");
+    client
+        .sender
+        .send(r.into())
+        .expect("Cannot send hover notification!");
 
     expect_diagnostics(&client);
 
     let msg = recv_msg(&client);
-    let hover_json = coerce_response(msg).result.expect("Expected hover response!");
+    let hover_json = coerce_response(msg)
+        .result
+        .expect("Expected hover response!");
     let hover_value = &hover_json.as_object().unwrap()["contents"]["value"];
-    assert_eq!("2", *hover_value.to_string().split("\\n").collect::<Vec<_>>().get(1).unwrap());
+    assert_eq!(
+        "2",
+        *hover_value
+            .to_string()
+            .split("\\n")
+            .collect::<Vec<_>>()
+            .get(1)
+            .unwrap()
+    );
 
-    handle.stop().join().expect("Failed to gracefully terminate LSP worker thread!");
+    handle
+        .stop()
+        .join()
+        .expect("Failed to gracefully terminate LSP worker thread!");
 }
 
 #[test]
@@ -159,17 +184,20 @@ fn test_rename() {
                 "character": 24,
             },
             "newName": "c",
-        })
+        }),
     };
-    client.sender.send(r.into()).expect("Cannot send rename request!");
+    client
+        .sender
+        .send(r.into())
+        .expect("Cannot send rename request!");
 
     expect_diagnostics(&client);
     let msg = recv_msg(&client);
 
-    let response = coerce_response(msg).result.expect("Expected rename response!");
-    let changes = &response
-        .as_object()
-        .unwrap()["changes"]["file:///code/default.nix"]
+    let response = coerce_response(msg)
+        .result
+        .expect("Expected rename response!");
+    let changes = &response.as_object().unwrap()["changes"]["file:///code/default.nix"]
         .as_array()
         .expect("Changes must be an array!");
 
@@ -212,7 +240,10 @@ fn test_rename() {
     assert_eq!(0, third["range"]["start"]["line"]);
     assert_eq!(0, third["range"]["end"]["line"]);
 
-    handle.stop().join().expect("Failed to gracefully terminate LSP worker thread!");
+    handle
+        .stop()
+        .join()
+        .expect("Failed to gracefully terminate LSP worker thread!");
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,7 +14,7 @@ use stoppable_thread::*;
 
 #[allow(dead_code)]
 fn eval(code: &str) -> NixValue {
-    let ast = rnix::parse(&code);
+    let ast = rnix::parse(code);
     let root = ast.root().inner().unwrap();
     let path = std::env::current_dir().unwrap();
     let out = Expr::parse(root, Gc::new(Scope::Root(path))).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -336,10 +336,7 @@ mod tests {
         assert_eq!(0, start.start.character);
         assert_eq!(1, start.end.character);
 
-        let actual_pos = range(expr, TextRange::new(
-            TextSize::from(15),
-            TextSize::from(20)
-        ));
+        let actual_pos = range(expr, TextRange::new(TextSize::from(15), TextSize::from(20)));
 
         assert_eq!(1, actual_pos.start.line);
         assert_eq!(1, actual_pos.end.line);
@@ -368,10 +365,13 @@ mod tests {
     #[test]
     fn test_lookup_pos_in_expr() {
         let expr = "let a = 1;\nbuiltins.trace a 23";
-        let pos = lookup_pos(expr, Position {
-            line: 0,
-            character: 0,
-        });
+        let pos = lookup_pos(
+            expr,
+            Position {
+                line: 0,
+                character: 0,
+            },
+        );
 
         assert_eq!(0, pos.expect("expected position to be not None!"));
     }
@@ -379,17 +379,29 @@ mod tests {
     #[test]
     fn test_lookup_pos_out_of_range() {
         let expr = "let a = 1;\na";
-        let pos_wrong_line = lookup_pos(expr, Position {
-            line: 5,
-            character: 23,
-        });
+        let pos_wrong_line = lookup_pos(
+            expr,
+            Position {
+                line: 5,
+                character: 23,
+            },
+        );
 
         assert!(pos_wrong_line.is_none());
 
         // if the character is greater than the length of a line, the offset of the last
         // char of the line is returned.
-        let pos_char_out_of_range = lookup_pos(expr, Position { line: 0, character: 100, });
-        assert_eq!(10, pos_char_out_of_range.expect("expected position to be not None!"));
+        let pos_char_out_of_range = lookup_pos(
+            expr,
+            Position {
+                line: 0,
+                character: 100,
+            },
+        );
+        assert_eq!(
+            10,
+            pos_char_out_of_range.expect("expected position to be not None!")
+        );
     }
 
     #[test]
@@ -398,21 +410,26 @@ mod tests {
         let root = rnix::parse(expr).node();
         let scope = scope_for(
             &Rc::new(Url::parse("file:///default.nix").unwrap()),
-            root.children().next().unwrap()
+            root.children().next().unwrap(),
         );
 
         assert!(scope.is_some());
         let scope_entries = scope.unwrap();
 
         assert_eq!(5, scope_entries.keys().len());
-        assert!(scope_entries.values().into_iter().all(|x| x.datatype == Datatype::Lambda));
-        assert!(vec!["n", "a", "b", "c", "d"].into_iter().all(|x| scope_entries.contains_key(x)));
+        assert!(scope_entries
+            .values()
+            .into_iter()
+            .all(|x| x.datatype == Datatype::Lambda));
+        assert!(vec!["n", "a", "b", "c", "d"]
+            .into_iter()
+            .all(|x| scope_entries.contains_key(x)));
 
         let mut iter = root.children().next().unwrap().children();
         iter.next();
         let scope_let = scope_for(
             &Rc::new(Url::parse("file:///default.nix").unwrap()),
-            iter.next().unwrap()
+            iter.next().unwrap(),
         );
 
         assert!(scope_let.is_some());
@@ -427,14 +444,16 @@ mod tests {
         let root = rnix::parse(expr).node();
         let scope = scope_for(
             &Rc::new(Url::parse("file:///default.nix").unwrap()),
-            root.children().next().unwrap()
+            root.children().next().unwrap(),
         );
 
         assert!(scope.is_some());
         let scope_entries = scope.unwrap();
 
         assert_eq!(2, scope_entries.keys().len());
-        assert!(vec!["a", "body"].into_iter().all(|x| scope_entries.contains_key(x)));
+        assert!(vec!["a", "body"]
+            .into_iter()
+            .all(|x| scope_entries.contains_key(x)));
     }
 
     #[test]


### PR DESCRIPTION
I ran `cargo fmt` + I applied a bunch of clippy lints (Basically all of the ones that aren't in `clippy::pedantic`)