### PR TITLE
Add overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,27 @@ Support for **Mac OS** is not guaranteed (see [PR #61](https://github.com/nix-co
 ```
 nix-env -i -f https://github.com/nix-community/rnix-lsp/archive/master.tar.gz
 ```
+### Using as overlay
+An example flake with home-manager integration:
+```
+{
+  inputs.rnix-lsp.url = "github:nix-community/rnix-lsp";
+  outputs = { self, ... }@inputs:
+    let
+      overlays = [
+          inputs.rnix-lsp.overlay
+        ];
+    in
+      homeConfigurations = {
+        machine = inputs.home-manager.lib.homeManagerConfiguration {
+          configuration = { pkgs, ... }:
+            {
+              nixpkgs.overlays = overlays;
+            };
+        };
+      };
+}
+```
 
 ## Integrate with your editor
 
@@ -113,6 +134,7 @@ If you run into an issue regarding "missing roots" see this [issue](https://gith
     "nix.enableLanguageServer": true
 }
 ```
+
 
 # RIP jd91mzm2
 

--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -3,7 +3,6 @@ let
     url = "https://github.com/edolstra/flake-compat/archive/12c64ca55c1014cdc1b16ed5a804aa8576601ff2.tar.gz";
     sha256 = "0jm6nzb83wa6ai17ly9fzpqc40wg1viib8klq8lby54agpl213w5";
   };
-in
-(import flake-compat {
+in (import flake-compat {
   src = ./.;
 })

--- a/flake.nix
+++ b/flake.nix
@@ -35,5 +35,17 @@
           drv = packages.rnix-lsp;
         };
         defaultApp = apps.rnix-lsp;
-      });
+      })
+      //
+      rec {
+        overlays = { 
+          default = final: prev: rec {
+          rnix-lsp = self.packages.${prev.system}.rnix-lsp;
+        };
+          nightly = final: prev: rec {
+          rnix-lsp-nightly = self.packages.${prev.system}.rnix-lsp;
+          };
+        };
+        overlay = overlays.default;
+    };
 }


### PR DESCRIPTION
### Summary & Motivation

Add `overlay` to `outputs` of the `flake`.
That way people can compose the unreleased versions better.


Add `rnix-lsp` `overlays` to the flake outputs, in order to be directly
    consumed by other flakes.

Provides 2 overlays:
    - default: with package named `rnix-lsp`, so people can overwrite their
      existing configuration
    - nightly: with package named `rnix-lsp-nightly`, so people can opt in
      to this package on a case-by-case basis

Also for now still uses the `overlay` attribute, for backwards
    compatibility, is that needed?

fixes:  #77
