### PR TITLE
feat: improved reformat edits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "rnix",
  "serde",
  "serde_json",
+ "smol_str",
  "stoppable_thread",
  "textedit-merge",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "nixpkgs-fmt"
 version = "1.2.0"
-source = "git+https://github.com/mtoohey31/nixpkgs-fmt?branch=feat/reformat-edits#80e18e670cd0a84785cbd0ba728ad8846e8e0e22"
+source = "git+https://github.com/mtoohey31/nixpkgs-fmt?branch=feat/reformat-edits#07ee0d8b538e3134c0b8bb4463e3caedb3501cb1"
 dependencies = [
  "clap",
  "crossbeam-channel 0.3.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,11 +96,12 @@ checksum = "328b822bdcba4d4e402be8d9adb6eebf269f969f8eadef977a553ff3c4fbcb58"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.3.9"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "crossbeam-utils 0.6.6",
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -115,10 +116,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.6.6"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
+ "autocfg",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
@@ -342,6 +344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,11 +366,11 @@ dependencies = [
 
 [[package]]
 name = "nixpkgs-fmt"
-version = "1.2.0"
-source = "git+https://github.com/mtoohey31/nixpkgs-fmt?branch=feat/reformat-edits#07ee0d8b538e3134c0b8bb4463e3caedb3501cb1"
+version = "1.3.0"
+source = "git+https://github.com/nix-community/nixpkgs-fmt#3c4addcc0aa9a6eb9fb64d9206733110d1153a52"
 dependencies = [
  "clap",
- "crossbeam-channel 0.3.9",
+ "crossbeam-channel 0.4.4",
  "ignore",
  "libc",
  "rnix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,14 +357,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "nixpkgs-fmt-rnix"
+name = "nixpkgs-fmt"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cd28a1c98361571955f6ddd71a27631671b025c49f4a5885cf4305ea82ba60"
+source = "git+https://github.com/mtoohey31/nixpkgs-fmt?branch=feat/reformat-edits#80e18e670cd0a84785cbd0ba728ad8846e8e0e22"
 dependencies = [
  "clap",
  "crossbeam-channel 0.3.9",
  "ignore",
+ "libc",
  "rnix",
  "rowan",
  "serde_json",
@@ -471,12 +471,13 @@ dependencies = [
  "lsp-server",
  "lsp-types",
  "maplit",
- "nixpkgs-fmt-rnix",
+ "nixpkgs-fmt",
  "regex",
  "rnix",
  "serde",
  "serde_json",
  "stoppable_thread",
+ "textedit-merge",
 ]
 
 [[package]]
@@ -619,6 +620,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textedit-merge"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9bb566d3c513aaadef8a4b2e805d75c5714e21b0a689c930365762ff0f2fc03"
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,9 +686,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ regex = "1.5.6"
 rnix = "0.10.2"
 serde = "1.0.138"
 serde_json = "1.0.82"
-nixpkgs-fmt = { git = "https://github.com/mtoohey31/nixpkgs-fmt", branch = "feat/reformat-edits" }
+nixpkgs-fmt = { git = "https://github.com/nix-community/nixpkgs-fmt" }
 smol_str = "0.1.17"
 textedit-merge = "0.2.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ regex = "1.5.6"
 rnix = "0.10.2"
 serde = "1.0.138"
 serde_json = "1.0.82"
-nixpkgs-fmt-rnix = "1.2.0"
+nixpkgs-fmt = { git = "https://github.com/mtoohey31/nixpkgs-fmt", branch = "feat/reformat-edits" }
+textedit-merge = "0.2.1"
 
 [dev-dependencies]
 stoppable_thread = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rnix = "0.10.2"
 serde = "1.0.138"
 serde_json = "1.0.82"
 nixpkgs-fmt = { git = "https://github.com/mtoohey31/nixpkgs-fmt", branch = "feat/reformat-edits" }
+smol_str = "0.1.17"
 textedit-merge = "0.2.1"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,7 @@ impl App {
         let start: usize = range.start().into();
         let end: usize = range.end().into();
         if start <= offset && offset < end {
-            return None;
+            return None
         }
 
         let (_definition_ast, definition_content, _) = self.files.get(&var.file)?;
@@ -391,7 +391,7 @@ impl App {
         let start: usize = range.start().into();
         let end: usize = range.end().into();
         if start <= offset && offset < end {
-            return None;
+            return None
         }
 
         let def_path = def.scope.root_path()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -356,7 +356,10 @@ mod tests {
         assert_eq!(0, start.start.character);
         assert_eq!(1, start.end.character);
 
-        let actual_pos = range(expr, TextRange::new(TextSize::from(15), TextSize::from(20)));
+        let actual_pos = range(expr, TextRange::new(
+            TextSize::from(15),
+            TextSize::from(20)
+        ));
 
         assert_eq!(1, actual_pos.start.line);
         assert_eq!(1, actual_pos.end.line);
@@ -385,13 +388,10 @@ mod tests {
     #[test]
     fn test_lookup_pos_in_expr() {
         let expr = "let a = 1;\nbuiltins.trace a 23";
-        let pos = lookup_pos(
-            expr,
-            Position {
-                line: 0,
-                character: 0,
-            },
-        );
+        let pos = lookup_pos(expr, Position {
+            line: 0,
+            character: 0,
+        });
 
         assert_eq!(0, pos.expect("expected position to be not None!"));
     }
@@ -399,29 +399,17 @@ mod tests {
     #[test]
     fn test_lookup_pos_out_of_range() {
         let expr = "let a = 1;\na";
-        let pos_wrong_line = lookup_pos(
-            expr,
-            Position {
-                line: 5,
-                character: 23,
-            },
-        );
+        let pos_wrong_line = lookup_pos(expr, Position {
+            line: 5,
+            character: 23,
+        });
 
         assert!(pos_wrong_line.is_none());
 
         // if the character is greater than the length of a line, the offset of the last
         // char of the line is returned.
-        let pos_char_out_of_range = lookup_pos(
-            expr,
-            Position {
-                line: 0,
-                character: 100,
-            },
-        );
-        assert_eq!(
-            10,
-            pos_char_out_of_range.expect("expected position to be not None!")
-        );
+        let pos_char_out_of_range = lookup_pos(expr, Position { line: 0, character: 100, });
+        assert_eq!(10, pos_char_out_of_range.expect("expected position to be not None!"));
     }
 
     #[test]
@@ -430,26 +418,21 @@ mod tests {
         let root = rnix::parse(expr).node();
         let scope = scope_for(
             &Rc::new(Url::parse("file:///default.nix").unwrap()),
-            root.children().next().unwrap(),
+            root.children().next().unwrap()
         );
 
         assert!(scope.is_some());
         let scope_entries = scope.unwrap();
 
         assert_eq!(5, scope_entries.keys().len());
-        assert!(scope_entries
-            .values()
-            .into_iter()
-            .all(|x| x.datatype == Datatype::Lambda));
-        assert!(vec!["n", "a", "b", "c", "d"]
-            .into_iter()
-            .all(|x| scope_entries.contains_key(x)));
+        assert!(scope_entries.values().into_iter().all(|x| x.datatype == Datatype::Lambda));
+        assert!(vec!["n", "a", "b", "c", "d"].into_iter().all(|x| scope_entries.contains_key(x)));
 
         let mut iter = root.children().next().unwrap().children();
         iter.next();
         let scope_let = scope_for(
             &Rc::new(Url::parse("file:///default.nix").unwrap()),
-            iter.next().unwrap(),
+            iter.next().unwrap()
         );
 
         assert!(scope_let.is_some());
@@ -464,16 +447,14 @@ mod tests {
         let root = rnix::parse(expr).node();
         let scope = scope_for(
             &Rc::new(Url::parse("file:///default.nix").unwrap()),
-            root.children().next().unwrap(),
+            root.children().next().unwrap()
         );
 
         assert!(scope.is_some());
         let scope_entries = scope.unwrap();
 
         assert_eq!(2, scope_entries.keys().len());
-        assert!(vec!["a", "body"]
-            .into_iter()
-            .all(|x| scope_entries.contains_key(x)));
+        assert!(vec!["a", "body"].into_iter().all(|x| scope_entries.contains_key(x)));
     }
 
     #[test]


### PR DESCRIPTION
<!--
Feel free to remove paragraphs that don't apply to your PR.
-->

### Summary & Motivation

<!--
Please summarize the changes you've made and the motivation behind it.
-->

The current method of reformatting documents consists of replacing the whole document with a single edit containing the reformatted version. This is sub-optimal for two main reasons:

1. It is inefficient, which could potentially be an issue with extremely large documents.
2. It can result in loosing your cursor position in the document in some editors, as @fufexan and I have experienced with [helix](https://github.com/helix-editor/helix).

This pull request updates the reformatting so that it sends multiple small edits, instead of one huge edit.

### Further context

<!--
If applicable, please give further context such as related issues / PRs,
an explanation of the problem you're aiming to solve or anything else you also
consider relevant.
-->

Since accomplishing this requires exposing the edits that `nixpkgs-fmt` uses internally, this depends on [nixpkgs-fmt#296](https://github.com/nix-community/nixpkgs-fmt/pull/296).

This pull request also adds one additional dependency: [textedit-merge](https://crates.io/crates/textedit-merge), which I wrote in the proccess of creating this PR. `nixpkgs-fmt` reformats the document with two sets of edits (spacing edits, then indentation edits), however, from my understanding, the language server protocol requires that the response to a reformatting request be a single set of textedits. Since the ranges in the indentation edits used by `nixpkgs-fmt` refer to the state of the document _after_ the spacing edits have been applied, a somewhat complex algorithm is required to merge the two sets of edits into a single set of edits that can be applied in one step.

One implementation detail that I would like a second opinion on are the data types:

- returned by the new `nixpkgs_fmt::reformat_edits` function
- accepted by `textedit_merge::merge`
- returned by `textedit_merge::merge`

The current choices for these data types (`(Vec<AtomEdit>, Vec<AtomEdit>)`, `&[(Range<usize>, AsRef<str>)]`, and `Vec<(Range<usize>, String)>` respectively) were chosen with the following goals in mind:

- minimal extra work being done in `nixpkgs_fmt::reformat_edits` (so that other users of this function can use it efficiently)
- no dependencies in `textedit-merge` (so that other users, if there ever are any, aren't tied to additional dependencies)

The main shortcoming of the current types is that the edits must be transformed twice, once from `Vec<AtomEdit>` to `Vec<(Range<usize>, AsRef<str>)>` for merging, then a second time from `Vec<(Range<usize>, String)>` to `Vec<TextEdit>` so they can be returned in the response to the reformatting request. If there's a way to do things that still achieves both of those goals while avoiding the double transformation, please let me know!

Finally, it would be dishonest of me if I didn't mention that I'm not 100% confident that `textedit-merge` is bug-free. I've tested reformatting on `nixpkgs-fmt`'s test cases and it works correctly on all of them _now_, but while I was working on it, I missed quite a few edge cases that those tests brought to light. If anyone can think of edge cases that might break edit merging, please give them a try! I'd much rather fix bugs with `textedit-merge` before merging this than find out about them later, as many of the bugs that I encountered during development resulted in panics since they involved indexing strings by invalid ranges.

Closes #81.