### PR TITLE
error diagnostics for unbound identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +470,7 @@ dependencies = [
  "log",
  "lsp-server",
  "lsp-types",
+ "maplit",
  "nixpkgs-fmt-rnix",
  "regex",
  "rnix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ nixpkgs-fmt-rnix = "1.2.0"
 
 [dev-dependencies]
 stoppable_thread = "0.2.1"
+maplit = "1"
 
 [features]
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -307,9 +307,11 @@ impl Expr {
                     },
                 }
             }
-            ParsedType::Ident(ident) => ExprSource::Ident {
-                name: ident.as_str().to_string(),
-            },
+            ParsedType::Ident(ident) => {
+                ExprSource::Ident {
+                    name: ident.as_str().to_string(),
+                }
+            }
             ParsedType::Dynamic(dynamic) => ExprSource::Dynamic {
                 inner: recurse_box(dynamic.inner().ok_or(ERR_PARSING)?),
             },

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -1,0 +1,95 @@
+use std::borrow::Borrow;
+
+use rnix::TextRange;
+
+use crate::{
+    error::{EvalError, Located, ValueError},
+    eval::{Expr, ExprSource},
+};
+
+/// If this node is an identifier, should it be a variable name ?
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Ident {
+    /// If this node is an identifier, it should be a variable name
+    IsVariable,
+    /// If this not is an identifier, it is not a variable name
+    ///
+    /// Example: foo in `bar.foo`
+    IsNotVariable,
+}
+
+/// If this is an error, maybe report it to acc. Otherwise, visit all children of this node
+/// to find evaluation errors and collect diagnostics on this accumulator
+fn visit_result<T: Borrow<Expr>>(
+    acc: &mut Vec<Located<ValueError>>,
+    result: &Result<T, EvalError>,
+    range: &Option<TextRange>,
+    ident_ctx: Ident,
+) {
+    match result {
+        Err(EvalError::Value(err)) => {
+            if let Some(range) = range {
+                acc.push(Located {
+                    range: range.clone(),
+                    kind: err.clone(),
+                })
+            }
+        }
+        Err(EvalError::Internal(_)) => {}
+        Ok(v) => visit(acc, v.borrow(), ident_ctx),
+    }
+}
+
+/// Visit all children of this node to find evaluation errors and collect
+/// diagnostics on this accumulator
+fn visit(acc: &mut Vec<Located<ValueError>>, node: &Expr, ident_ctx: Ident) {
+    use Ident::*;
+    match &node.source {
+        ExprSource::AttrSet { definitions } => {
+            for i in definitions.iter() {
+                visit_result(acc, i, &node.range, IsVariable)
+            }
+        }
+        ExprSource::KeyValuePair { key, value } => {
+            visit_result(acc, key, &node.range, IsNotVariable);
+            visit_result(acc, value, &node.range, IsVariable);
+        }
+        ExprSource::Select { from, index } => {
+            visit_result(acc, from, &node.range, IsVariable);
+            visit_result(acc, index, &node.range, IsNotVariable);
+        }
+        ExprSource::Ident { name } => {
+            if ident_ctx == IsVariable {
+                if let Some(range) = &node.range {
+                    // check that the variable is bound
+                    if node.scope.get_let(name).is_none() {
+                        acc.push(Located {
+                            range: range.clone(),
+                            kind: ValueError::UnboundIdentifier(name.clone()),
+                        });
+                    }
+                }
+            }
+        }
+        ExprSource::Literal { .. } => {}
+        ExprSource::UnaryInvert { value: inner }
+        | ExprSource::UnaryNegate { value: inner }
+        | ExprSource::Dynamic { inner }
+        | ExprSource::Paren { inner } => visit_result(acc, inner, &node.range, IsVariable),
+        ExprSource::BinOp { left, right, .. }
+        | ExprSource::BoolAnd { left, right }
+        | ExprSource::Implication { left, right }
+        | ExprSource::BoolOr { left, right } => {
+            visit_result(acc, left, &node.range, IsVariable);
+            visit_result(acc, right, &node.range, IsVariable);
+        }
+    }
+}
+/// Looks for errors in the user code. Attempts to return no false positives.
+///
+/// Current analysis can detect undefined variables.
+pub fn check(node: &Expr) -> Vec<Located<ValueError>> {
+    let mut res = Vec::new();
+    visit(&mut res, node, Ident::IsVariable);
+    res
+}


### PR DESCRIPTION
<!--
Feel free to remove paragraphs that don't apply to your PR.
-->

### Summary & Motivation

find at least as much stuff as nix-instantiate --parse-only

currently not very useful because rnix-lsp cannot parse let .. in nor lambda constructs, and they are present in nearly every file.

![image](https://user-images.githubusercontent.com/12595971/174452006-dba56928-ad0b-46b9-834d-3c78bc1e7c20.png)

