### PR TITLE
feat: format via alejandra when feature is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alejandra"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2523e3312f47f4b28c443249c1d25fe7a71e4719198a8889fcc41a155032cb7f"
+dependencies = [
+ "mimalloc",
+ "rnix",
+ "rowan",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +71,12 @@ checksum = "29b6ad25ae296159fb0da12b970b2fe179b234584d7cd294c891e2bbb284466b"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -296,6 +313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ca136052550448f55df7898c6dbe651c6b574fe38a0d9ea687a9f8088a2e2c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +380,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f64ad83c969af2e732e907564deb0d0ed393cec4af80776f77dd77a1a427698"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -462,6 +497,7 @@ dependencies = [
 name = "rnix-lsp"
 version = "0.3.0-dev"
 dependencies = [
+ "alejandra",
  "dirs",
  "env_logger",
  "gc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ log = "0.4.17"
 lsp-server = "0.6.0"
 lsp-types = { version = "0.93.0", features = ["proposed"] }
 regex = "1.5.6"
+alejandra = { version = "1.5.0", optional = true }
 rnix = "0.10.2"
 serde = "1.0.138"
 serde_json = "1.0.82"
-nixpkgs-fmt-rnix = "1.2.0"
+nixpkgs-fmt-rnix = { version = "1.2.0", optional = true }
 
 [dev-dependencies]
 stoppable_thread = "0.2.1"
@@ -32,7 +33,7 @@ maplit = "1"
 [features]
 
 # Set this to ["verbose"] when debugging
-default = []
+default = [ "nixpkgs-fmt-rnix" ]
 
 # Enable showing internal errors via editor UI, such as via hover popups.
 # This can be helpful for debugging, but we don't want the evaluator to


### PR DESCRIPTION
Refs #80 
Refs #81 

### Summary & Motivation

It's nice to give users freedom of choosing the formatter to use. I think that the correct approach would be to parse this from `flake.nix` `formatter` and/or expose this via LSP config.
For now, just added a simple solution, which is fully backwards-compatible and does not introduce additional dependencies.

When `--features alejandra` is specified, https://github.com/kamadorueda/alejandra is used as the formatter.
https://github.com/nix-community/nixpkgs-fmt is still the default, but can be disabled at compile-time via `--no-default-features`

Until merged this can be consumed via https://github.com/NixOS/nixpkgs/commit/5ddf7f7edaf2edd75e8b42871e86f9f412146431 in `nixpkgs`