### PR TITLE
Unpin the version of Nix used as a checkInput

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
           pname = "rnix-lsp";
           root = ./.;
           doCheck = true;
-          checkInputs = [ pkgs.nix_2_4 ];
+          checkInputs = [ pkgs.nix ];
         };
         defaultPackage = packages.rnix-lsp;
 


### PR DESCRIPTION
<!--
Feel free to remove paragraphs that don't apply to your PR.
-->

### Summary & Motivation

<!--
Please summarize the changes you've made and the motivation behind it.
-->

This pull request unpins the version of Nix used as a `checkInput` for the flake's default package. I assume `nix_2_4` was necessary in the past, but there doesn't seem to be any issue with using plain old `pkgs.nix` with the flake's current version of `nixpkgs`.

If there's a reason it should stay as `nix_2_4`, let me know! I've been having quite the time trying to override things so `nix_2_4` doesn't get evaluated, because an error is thrown as soon as it does, and I haven't managed to find something that works yet, so I think some kind of change will be necessary to get this working with nixpkgs-unstable either way.

### Further context

<!--
If applicable, please give further context such as related issues / PRs,
an explanation of the problem you're aiming to solve or anything else you also
consider relevant.
-->

Closes #92.