### PR TITLE
fix: update Nix version detection regex for loading builtins

### DIFF
--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -191,7 +191,7 @@ impl App {
             Ok(out) => {
                 match str::from_utf8(&out.stdout) {
                     Ok(v) => {
-                        let re = regex::Regex::new(r"^nix \(Nix\) (?P<major>\d)\.(?P<minor>\d).*").unwrap();
+                        let re = regex::Regex::new(r"^nix \(Nix\) (?P<major>\d+)\.(?P<minor>\d+).*").unwrap();
                         let m = re.captures(v).unwrap();
                         let major = m.name("major").map_or(1, |m| m.as_str().parse::<u8>().unwrap());
                         let minor = m.name("minor").map_or(1, |m| m.as_str().parse::<u8>().unwrap());


### PR DESCRIPTION
<!--
Feel free to remove paragraphs that don't apply to your PR.
-->

### Summary & Motivation

<!--
Please summarize the changes you've made and the motivation behind it.
-->

This pull request fixes the version detection regex used when loading the builtins using the nix command so that it doesn't assume that major and minor versions are limited to single digits.

### Further context

<!--
If applicable, please give further context such as related issues / PRs,
an explanation of the problem you're aiming to solve or anything else you also
consider relevant.
-->

Actually resolves #92, since the command in question there still fails after #93, except it's failing due to `lookup::tests::test_provide_builtins_non_mac` failing since nix 2.10.3's version breaks the current regex.

I also have a more in-depth overhaul of `load_builtins` at https://github.com/mtoohey31/rnix-lsp/tree/fix/dump-builtins-compat-alternate with better error checking that tries the command regardless of version so we don't have to rely on a brittle regex, but I'd be fine with either of the two branches being merged.