### PR TITLE
Static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ rnix = "0.10.2"
 serde = "1.0.138"
 serde_json = "1.0.82"
 nixpkgs-fmt-rnix = "1.2.0"
+maplit = "1"
 
 [dev-dependencies]
 stoppable_thread = "0.2.1"
-maplit = "1"
 
 [features]
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,7 +79,7 @@ pub struct Located<T: Error + Clone + Trace + Finalize> {
     #[unsafe_ignore_trace]
     pub range: TextRange,
     /// The nature of the issue
-    pub kind: T
+    pub kind: T,
 }
 
 impl<T: Error + Clone + Trace + Finalize> std::error::Error for Located<T> {}
@@ -117,7 +117,9 @@ impl std::fmt::Display for ValueError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             ValueError::DivisionByZero => write!(f, "division by zero"),
-            ValueError::AttrAlreadyDefined(name) => write!(f, "attribute `{}` defined more than once", name),
+            ValueError::AttrAlreadyDefined(name) => {
+                write!(f, "attribute `{}` defined more than once", name)
+            }
             ValueError::TypeError(msg) => write!(f, "{}", msg),
             ValueError::UnboundIdentifier(name) => write!(f, "identifier {} is unbound", name),
         }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -73,6 +73,13 @@ pub enum ExprSource {
         from: ExprResultGc,
         index: ExprResultBox,
     },
+    /// `assert condition; body`
+    Assert {
+        /// the asserted condition
+        condition: ExprResultBox,
+        /// the body which is only evaluated if the assertion is true
+        body: ExprResultBox,
+    },
     /// Dynamic attribute, such as the curly braces in `foo.${toString (1+1)}`
     Dynamic {
         inner: ExprResultBox,
@@ -304,6 +311,9 @@ impl Expr {
                     }
                 }))
             }
+            ExprSource::Assert { .. } => Err(EvalError::Internal(InternalError::Unimplemented(
+                "evaluating `assert` operator is not implemented".to_string(),
+            ))),
             ExprSource::OrDefault { .. } => Err(EvalError::Internal(InternalError::Unimplemented(
                 "evaluating `or` default operator is not implemented".to_string(),
             ))),
@@ -371,6 +381,7 @@ impl Expr {
             ExprSource::BinOp { op: _, left, right } => vec![left, right],
             ExprSource::BoolAnd { left, right } => vec![left, right],
             ExprSource::BoolOr { left, right } => vec![left, right],
+            ExprSource::Assert { condition, body } => vec![condition, body],
             ExprSource::Implication { left, right } => vec![left, right],
             ExprSource::OrDefault { index, default } => vec![index, default],
             ExprSource::UnaryInvert { value } => vec![value],

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -97,6 +97,15 @@ pub enum ExprSource {
     Literal {
         value: NixValue,
     },
+    /// `if condition then body else else_body`
+    IfElse {
+        /// the condition evaluated
+        condition: ExprResultBox,
+        /// the body evaluated when the condition is true
+        body: ExprResultBox,
+        /// the body evaluated when the condition is false
+        else_body: ExprResultBox,
+    },
     /// A string, possibly interpolated
     String {
         /// interpolated and literal parts of this string
@@ -311,6 +320,9 @@ impl Expr {
                     }
                 }))
             }
+            ExprSource::IfElse { .. } => Err(EvalError::Internal(InternalError::Unimplemented(
+                "evaluating `if` is not implemented".to_string(),
+            ))),
             ExprSource::Assert { .. } => Err(EvalError::Internal(InternalError::Unimplemented(
                 "evaluating `assert` operator is not implemented".to_string(),
             ))),
@@ -381,6 +393,7 @@ impl Expr {
             ExprSource::BinOp { op: _, left, right } => vec![left, right],
             ExprSource::BoolAnd { left, right } => vec![left, right],
             ExprSource::BoolOr { left, right } => vec![left, right],
+            ExprSource::IfElse { condition, body, else_body } => vec![condition, body, else_body],
             ExprSource::Assert { condition, body } => vec![condition, body],
             ExprSource::Implication { left, right } => vec![left, right],
             ExprSource::OrDefault { index, default } => vec![index, default],

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -120,6 +120,9 @@ pub enum ExprSource {
     UnaryNegate {
         value: ExprResultBox,
     },
+    List {
+        elements: Vec<ExprResultGc>,
+    },
 }
 
 /// Syntax node that has context and can be lazily evaluated.
@@ -271,6 +274,7 @@ impl Expr {
                     }
                 }))
             }
+            ExprSource::List { .. } => Err(EvalError::Internal(InternalError::Unimplemented("evaluating lists is not implemented".to_string()))),
             ExprSource::Apply { .. } => Err(EvalError::Internal(InternalError::Unimplemented("evaluating function application is not implemented".to_string()))),
             ExprSource::Lambda { .. } => Err(EvalError::Internal(InternalError::Unimplemented("evaluating function is not implemented".to_string()))),
             ExprSource::Pattern { .. } => Err(EvalError::Internal(InternalError::Unimplemented("evaluating function argument pattern is not implemented".to_string()))),
@@ -334,6 +338,15 @@ impl Expr {
                 return res
             },
             ExprSource::Lambda { arg, body } => vec![arg, body],
+            ExprSource::List { elements } => {
+                let mut res = vec![];
+                for entry in elements.iter() {
+                    if let Ok(default) = entry {
+                        res.push(default.as_ref());
+                    }
+                }
+                return res
+            }
             ExprSource::AttrSet {
                 definitions,
             } => {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -95,6 +95,13 @@ pub enum ExprSource {
         /// interpolated and literal parts of this string
         parts: Vec<StringPartSource>,
     },
+    /// `a.b or c`
+    OrDefault {
+        /// `a.b`, of type `Select`
+        index: ExprResultBox,
+        /// `c`
+        default: ExprResultBox,
+    },
     Paren {
         inner: ExprResultBox,
     },
@@ -297,6 +304,9 @@ impl Expr {
                     }
                 }))
             }
+            ExprSource::OrDefault { .. } => Err(EvalError::Internal(InternalError::Unimplemented(
+                "evaluating `or` default operator is not implemented".to_string(),
+            ))),
             ExprSource::With { .. } => Err(EvalError::Internal(InternalError::Unimplemented(
                 "evaluating with expressions is not implemented".to_string(),
             ))),
@@ -362,6 +372,7 @@ impl Expr {
             ExprSource::BoolAnd { left, right } => vec![left, right],
             ExprSource::BoolOr { left, right } => vec![left, right],
             ExprSource::Implication { left, right } => vec![left, right],
+            ExprSource::OrDefault { index, default } => vec![index, default],
             ExprSource::UnaryInvert { value } => vec![value],
             ExprSource::UnaryNegate { value } => vec![value],
             ExprSource::Apply { function, arg } => vec![function, arg],

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -511,11 +511,17 @@ impl Expr {
                     condition: recurse_option_box(ifelse.condition()),
                 }
             },
-            ParsedType::Key(_) | ParsedType::Inherit(_) => {
-                // keys are handled in KeyValuePair and Inherit in let in/attrset
+            ParsedType::Key(_) | ParsedType::KeyValue(_)
+            | ParsedType::Inherit(_) | ParsedType::InheritFrom(_)
+            | ParsedType::PatBind(_) | ParsedType::PatEntry(_) => {
+                // keys are handled in KeyValuePair
+                // inherit in let in/attrset
+                // patterns in lambda
                 return Err(EvalError::Internal(InternalError::Unexpected(format!("this kind of node {:?} should have been handled as part of another node type", node))))
             }
-            node => {
+            ParsedType::Error(_) => return Err(ERR_PARSING),
+            ParsedType::PathWithInterpol(_) |
+            ParsedType::LegacyLet(_) | ParsedType::Root(_) => {
                 return Err(EvalError::Internal(InternalError::Unimplemented(format!(
                     "rnix-parser node {:?}",
                     node

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -504,6 +504,13 @@ impl Expr {
                     condition: recurse_option_box(assert.condition()),
                 }
             },
+            ParsedType::IfElse(ifelse) => {
+                ExprSource::IfElse {
+                    body: recurse_option_box(ifelse.body()),
+                    else_body: recurse_option_box(ifelse.else_body()),
+                    condition: recurse_option_box(ifelse.condition()),
+                }
+            },
             node => {
                 return Err(EvalError::Internal(InternalError::Unimplemented(format!(
                     "rnix-parser node {:?}",

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -36,6 +36,218 @@ pub enum BinOpKind {
     NotEqual,
 }
 
+/// Parse a node with `key = value;` pairs like an attrset or let in
+///
+/// Returns the scope unchanged if is_recursive is false or a new one with the `key = value;`
+/// bindings added.
+fn parse_entry_holder<T: EntryHolder>(
+    node: &T,
+    scope: Gc<Scope>,
+    is_recursive: bool,
+) -> Result<
+    (
+        HashMap<String, Gc<Expr>>,
+        Vec<Result<Gc<Expr>, EvalError>>,
+        Gc<Scope>,
+    ),
+    EvalError,
+> {
+    // Create a new scope if we're a recursive attr set. We'll later
+    // populate this scope with the non-dynamic keys of the set.
+    let new_scope = if is_recursive {
+        let new = Scope::Let {
+            parent: scope.clone(),
+            contents: GcCell::new(HashMap::new()),
+        };
+        Gc::new(new)
+    } else {
+        scope.clone()
+    };
+
+    // Used for the NixValue of this attribute set.
+    let mut value_map = HashMap::new();
+    // Used for the ExprSource. See ExprSource::AttrSet for
+    // details on why we create both a hashmap and a vector.
+    let mut definitions = vec![];
+
+    for entry in node.entries() {
+        // Where x, y, z are KeyValuePairs:
+        //
+        //   services.bluetooth.enable = true;
+        //                      +------------+ x
+        //            +----------------------+ y
+        //   +-------------------------------+ z
+        //
+        // Hovering over `x` should show `true`.
+        // Hovering over `y` should show `{ enable }`.
+        // Hovering over `z` should show `{ bluetooth }`.
+        //
+        // This matches what we would see for verbose syntax:
+        //
+        //   services = { bluetooth = { enable = true; }; };
+        //
+        // So, we rewrite paths into the verbose syntax.
+
+        let mut path = entry
+            .key()
+            .ok_or(ERR_PARSING)?
+            .path()
+            .map(|node| Expr::parse(node, scope.clone()).map(Gc::new))
+            .collect::<Vec<_>>();
+
+        // NOTE: This pops from the end, so we want to remove
+        //       the inmost element before reversing
+        let inmost_key = path.pop().unwrap()?;
+
+        // After this, our path lists path elements from right to left
+        path.reverse();
+
+        let inmost_value_syntax = entry.value().ok_or(ERR_PARSING)?;
+        let entry_end = inmost_value_syntax.text_range().end();
+        let inmost_value = Expr::parse(inmost_value_syntax, new_scope.clone())?;
+
+        let here_start = inmost_key.range.ok_or(ERR_PARSING)?.start();
+
+        let mut cursor_range = TextRange::new(here_start, entry_end);
+        let mut cursor_key_name = inmost_key.as_ident()?;
+        let mut cursor_value = Gc::new(Expr {
+            value: GcCell::new(None),
+            source: ExprSource::KeyValuePair {
+                key: Ok(inmost_key),
+                value: Ok(Gc::new(inmost_value)),
+            },
+            range: Some(cursor_range),
+            scope: new_scope.clone(),
+        });
+
+        for element in path {
+            let here_start = element.as_ref()?.range.ok_or(ERR_PARSING)?.start();
+
+            // Create an invisible attr set
+            let tmp_map = NixValue::Map(HashMap::from_iter(vec![(
+                cursor_key_name,
+                cursor_value.clone(),
+            )]));
+            let tmp_attr_set = Gc::new(Expr {
+                value: GcCell::new(Some(Gc::new(tmp_map))),
+                source: ExprSource::AttrSet {
+                    definitions: vec![Ok(cursor_value)],
+                },
+                range: Some(cursor_range),
+                scope: new_scope.clone(),
+            });
+
+            cursor_range = TextRange::new(here_start, entry_end);
+            cursor_key_name = element.as_ref()?.as_ident()?;
+            cursor_value = Gc::new(Expr {
+                value: GcCell::new(None),
+                source: ExprSource::KeyValuePair {
+                    key: element,
+                    value: Ok(tmp_attr_set),
+                },
+                range: Some(cursor_range.clone()),
+                scope: new_scope.clone(),
+            });
+        }
+
+        definitions.push(Ok(cursor_value.clone()));
+
+        // Merge values if needed. For example:
+        // { a.b = 1; a.c = 2; } => { a = { b = 1; c = 2; }; }
+        let merged_value = match value_map.get(&cursor_key_name) as Option<&Gc<Expr>> {
+            Some(existing) => merge_set_literal(
+                cursor_key_name.clone(),
+                existing.clone(),
+                cursor_value.clone(),
+            )?,
+            None => cursor_value,
+        };
+        value_map.insert(cursor_key_name, merged_value);
+    }
+
+    use std::collections::hash_map::Entry;
+
+    // Note that we don't query the scope yet, since that would
+    // cause expressions like `with pkgs; { inherit htop; }` to
+    // evaluate the `with` statement earlier than needed. Instead
+    // we create ExprSource::Ident and ExprSource::Select expressions
+    // then put those in the attribute set.
+    for inherit in node.inherits() {
+        // Handle syntax like `inherit (some_expression) foo` by
+        // rewriting it to `foo = some_expression.foo`, allowing
+        // `some_expression` to be lazily evaluated.
+        if let Some(from) = inherit.from() {
+            let from = Gc::new(Expr::parse(
+                from.inner().ok_or(ERR_PARSING)?,
+                new_scope.clone(),
+            )?);
+
+            // For our example described above, add `some_expression`,
+            // `foo`, and `bar` to the ExprSource so they're all visible
+            // to interactive tooling.
+            definitions.push(Ok(from.clone()));
+
+            for ident in inherit.idents() {
+                let name = ident.as_str();
+                let index = Box::new(Expr {
+                    value: GcCell::new(None),
+                    source: ExprSource::Ident {
+                        name: name.to_string(),
+                    },
+                    range: None,
+                    scope: scope.clone(),
+                });
+                let attr = Gc::new(Expr {
+                    value: GcCell::new(None),
+                    source: ExprSource::Select {
+                        from: Ok(from.clone()),
+                        index: Ok(index),
+                    },
+                    range: Some(ident.node().text_range()),
+                    scope: scope.clone(),
+                });
+                definitions.push(Ok(attr.clone()));
+                let name = name.to_string();
+                match value_map.entry(name.clone()) {
+                    Entry::Occupied(_) => {
+                        return Err(EvalError::Value(ValueError::AttrAlreadyDefined(name)))
+                    }
+                    Entry::Vacant(entry) => entry.insert(attr),
+                };
+            }
+        } else {
+            // Handle `inherit` from scope
+            for ident in inherit.idents() {
+                let name = ident.as_str();
+                let attr = Gc::new(Expr {
+                    value: GcCell::new(None),
+                    source: ExprSource::Ident {
+                        name: name.to_string(),
+                    },
+                    range: Some(ident.node().text_range()),
+                    scope: scope.clone(),
+                });
+                definitions.push(Ok(attr.clone()));
+                let name = name.to_string();
+                match value_map.entry(name.clone()) {
+                    Entry::Occupied(_) => {
+                        return Err(EvalError::Value(ValueError::AttrAlreadyDefined(name)))
+                    }
+                    Entry::Vacant(entry) => entry.insert(attr),
+                };
+            }
+        }
+    }
+
+    if is_recursive {
+        // update the scope to include our hashmap
+        if let Scope::Let { contents, .. } = new_scope.borrow() {
+            *contents.borrow_mut() = value_map.clone();
+        }
+    }
+    Ok((value_map, definitions, new_scope))
+}
+
 impl Expr {
     /// Convert a rnix-parser tree into a syntax tree that can be lazily evaluated.
     ///
@@ -53,199 +265,8 @@ impl Expr {
             ParsedType::AttrSet(set) => {
                 let is_recursive = set.recursive();
 
-                // Create a new scope if we're a recursive attr set. We'll later
-                // populate this scope with the non-dynamic keys of the set.
-                let new_scope = if is_recursive {
-                    let new = Scope::Let {
-                        parent: scope.clone(),
-                        contents: GcCell::new(HashMap::new()),
-                    };
-                    Gc::new(new)
-                } else {
-                    scope.clone()
-                };
-
-                // Used for the NixValue of this attribute set.
-                let mut value_map = HashMap::new();
-                // Used for the ExprSource. See ExprSource::AttrSet for
-                // details on why we create both a hashmap and a vector.
-                let mut definitions = vec![];
-
-                for entry in set.entries() {
-                    // Where x, y, z are KeyValuePairs:
-                    //
-                    //   services.bluetooth.enable = true;
-                    //                      +------------+ x
-                    //            +----------------------+ y
-                    //   +-------------------------------+ z
-                    //
-                    // Hovering over `x` should show `true`.
-                    // Hovering over `y` should show `{ enable }`.
-                    // Hovering over `z` should show `{ bluetooth }`.
-                    //
-                    // This matches what we would see for verbose syntax:
-                    //
-                    //   services = { bluetooth = { enable = true; }; };
-                    //
-                    // So, we rewrite paths into the verbose syntax.
-
-                    let mut path = entry
-                        .key()
-                        .ok_or(ERR_PARSING)?
-                        .path()
-                        .map(|node| Self::parse(node, scope.clone()).map(Gc::new))
-                        .collect::<Vec<_>>();
-
-                    // NOTE: This pops from the end, so we want to remove
-                    //       the inmost element before reversing
-                    let inmost_key = path.pop().unwrap()?;
-
-                    // After this, our path lists path elements from right to left
-                    path.reverse();
-
-                    let inmost_value_syntax = entry.value().ok_or(ERR_PARSING)?;
-                    let entry_end = inmost_value_syntax.text_range().end();
-                    let inmost_value = Self::parse(inmost_value_syntax, new_scope.clone())?;
-
-                    let here_start = inmost_key.range.ok_or(ERR_PARSING)?.start();
-
-                    let mut cursor_range = TextRange::new(here_start, entry_end);
-                    let mut cursor_key_name = inmost_key.as_ident()?;
-                    let mut cursor_value = Gc::new(Expr {
-                        value: GcCell::new(None),
-                        source: ExprSource::KeyValuePair {
-                            key: Ok(inmost_key),
-                            value: Ok(Gc::new(inmost_value)),
-                        },
-                        range: Some(cursor_range),
-                        scope: new_scope.clone(),
-                    });
-
-                    for element in path {
-                        let here_start = element.as_ref()?.range.ok_or(ERR_PARSING)?.start();
-
-                        // Create an invisible attr set
-                        let tmp_map = NixValue::Map(HashMap::from_iter(vec![(
-                            cursor_key_name,
-                            cursor_value.clone(),
-                        )]));
-                        let tmp_attr_set = Gc::new(Expr {
-                            value: GcCell::new(Some(Gc::new(tmp_map))),
-                            source: ExprSource::AttrSet {
-                                definitions: vec![Ok(cursor_value)],
-                            },
-                            range: Some(cursor_range),
-                            scope: new_scope.clone(),
-                        });
-
-                        cursor_range = TextRange::new(here_start, entry_end);
-                        cursor_key_name = element.as_ref()?.as_ident()?;
-                        cursor_value = Gc::new(Expr {
-                            value: GcCell::new(None),
-                            source: ExprSource::KeyValuePair {
-                                key: element,
-                                value: Ok(tmp_attr_set),
-                            },
-                            range: Some(cursor_range.clone()),
-                            scope: new_scope.clone(),
-                        });
-                    }
-
-                    definitions.push(Ok(cursor_value.clone()));
-
-                    // Merge values if needed. For example:
-                    // { a.b = 1; a.c = 2; } => { a = { b = 1; c = 2; }; }
-                    let merged_value = match value_map.get(&cursor_key_name) as Option<&Gc<Expr>> {
-                        Some(existing) => merge_set_literal(
-                            cursor_key_name.clone(),
-                            existing.clone(),
-                            cursor_value.clone(),
-                        )?,
-                        None => cursor_value,
-                    };
-                    value_map.insert(cursor_key_name, merged_value);
-                }
-
-                use std::collections::hash_map::Entry;
-
-                // Note that we don't query the scope yet, since that would
-                // cause expressions like `with pkgs; { inherit htop; }` to
-                // evaluate the `with` statement earlier than needed. Instead
-                // we create ExprSource::Ident and ExprSource::Select expressions
-                // then put those in the attribute set.
-                for inherit in set.inherits() {
-                    // Handle syntax like `inherit (some_expression) foo` by
-                    // rewriting it to `foo = some_expression.foo`, allowing
-                    // `some_expression` to be lazily evaluated.
-                    if let Some(from) = inherit.from() {
-                        let from = Gc::new(Self::parse(
-                            from.inner().ok_or(ERR_PARSING)?,
-                            new_scope.clone(),
-                        )?);
-
-                        // For our example described above, add `some_expression`,
-                        // `foo`, and `bar` to the ExprSource so they're all visible
-                        // to interactive tooling.
-                        definitions.push(Ok(from.clone()));
-
-                        for ident in inherit.idents() {
-                            let name = ident.as_str();
-                            let index = Box::new(Expr {
-                                value: GcCell::new(None),
-                                source: ExprSource::Ident {
-                                    name: name.to_string(),
-                                },
-                                range: None,
-                                scope: scope.clone(),
-                            });
-                            let attr = Gc::new(Expr {
-                                value: GcCell::new(None),
-                                source: ExprSource::Select {
-                                    from: Ok(from.clone()),
-                                    index: Ok(index),
-                                },
-                                range: Some(ident.node().text_range()),
-                                scope: scope.clone(),
-                            });
-                            definitions.push(Ok(attr.clone()));
-                            let name = name.to_string();
-                            match value_map.entry(name.clone()) {
-                                Entry::Occupied(_) => {
-                                    return Err(EvalError::Value(ValueError::AttrAlreadyDefined(name)))
-                                }
-                                Entry::Vacant(entry) => entry.insert(attr),
-                            };
-                        }
-                    } else {
-                        // Handle `inherit` from scope
-                        for ident in inherit.idents() {
-                            let name = ident.as_str();
-                            let attr = Gc::new(Expr {
-                                value: GcCell::new(None),
-                                source: ExprSource::Ident {
-                                    name: name.to_string(),
-                                },
-                                range: Some(ident.node().text_range()),
-                                scope: scope.clone(),
-                            });
-                            definitions.push(Ok(attr.clone()));
-                            let name = name.to_string();
-                            match value_map.entry(name.clone()) {
-                                Entry::Occupied(_) => {
-                                    return Err(EvalError::Value(ValueError::AttrAlreadyDefined(name)))
-                                }
-                                Entry::Vacant(entry) => entry.insert(attr),
-                            };
-                        }
-                    }
-                }
-
-                if is_recursive {
-                    // update the scope to include our hashmap
-                    if let Scope::Let { contents, .. } = new_scope.borrow() {
-                        *contents.borrow_mut() = value_map.clone();
-                    }
-                }
+                let (value_map, definitions, new_scope) =
+                    parse_entry_holder(&set, scope, is_recursive)?;
 
                 return Ok(Expr {
                     value: GcCell::new(Some(Gc::new(NixValue::Map(value_map)))),
@@ -334,6 +355,21 @@ impl Expr {
                         }
                     },
                 }
+            }
+            ParsedType::LetIn(letin) => {
+                let (_value_map, definitions, new_scope) =
+                    parse_entry_holder(&letin, scope.clone(), true)?;
+                let body = letin.body().ok_or(ERR_PARSING)?;
+                let body_source = Expr::parse(body, new_scope.clone()).map(Box::new);
+                return Ok(Expr {
+                    value: GcCell::new(None),
+                    source: ExprSource::LetIn {
+                        definitions,
+                        body: body_source,
+                    },
+                    range,
+                    scope: new_scope,
+                });
             }
             node => {
                 return Err(EvalError::Internal(InternalError::Unimplemented(format!(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -511,6 +511,10 @@ impl Expr {
                     condition: recurse_option_box(ifelse.condition()),
                 }
             },
+            ParsedType::Key(_) | ParsedType::Inherit(_) => {
+                // keys are handled in KeyValuePair and Inherit in let in/attrset
+                return Err(EvalError::Internal(InternalError::Unexpected(format!("this kind of node {:?} should have been handled as part of another node type", node))))
+            }
             node => {
                 return Err(EvalError::Internal(InternalError::Unimplemented(format!(
                     "rnix-parser node {:?}",

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -445,6 +445,11 @@ impl Expr {
                         body
                 }
             },
+            ParsedType::List(list) => {
+                ExprSource::List {
+                    elements: list.items().map(recurse_gc).collect()
+                }
+            }
             node => {
                 return Err(EvalError::Internal(InternalError::Unimplemented(format!(
                     "rnix-parser node {:?}",

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -498,6 +498,12 @@ impl Expr {
                 }
                 ExprSource::String { parts }
             }
+            ParsedType::Assert(assert) => {
+                ExprSource::Assert {
+                    body: recurse_option_box(assert.body()),
+                    condition: recurse_option_box(assert.condition()),
+                }
+            },
             node => {
                 return Err(EvalError::Internal(InternalError::Unimplemented(format!(
                     "rnix-parser node {:?}",

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,6 +1,7 @@
 use crate::eval::{Expr, ExprSource};
 use crate::value::NixValue;
 use gc::{Finalize, Gc, GcCell, Trace};
+use std::collections::HashSet;
 use std::{collections::HashMap, path::PathBuf};
 
 /// A parent Expr's scope is used to provide tooling for its child Exprs.
@@ -25,7 +26,29 @@ pub enum Scope {
         parent: Gc<Scope>,
         contents: GcCell<HashMap<String, Gc<Expr>>>,
     },
+    /// Binding introduced as a function argument or function argument pattern
+    FunctionArguments {
+        parent: Gc<Scope>,
+        /// names bound
+        names: GcCell<HashSet<String>>,
+    },
     None,
+}
+
+/// How a binding might be defined
+#[derive(Debug, Clone)]
+pub enum Definition {
+    /// Might be either unbound or bound dynamically by `with`
+    #[allow(dead_code)]
+    PossiblyDynamic,
+    /// Here is the expression that defines this variable
+    Expression(Gc<Expr>),
+    /// this variable is a formal argument of a function
+    Argument,
+    /// this variable is definitely not defined
+    Unbound,
+    /// builtins
+    Ambient,
 }
 
 impl Scope {
@@ -52,8 +75,16 @@ impl Scope {
     }
 
     pub fn get_let(&self, name: &str) -> Option<Gc<Expr>> {
+        match self.get_definition(name) {
+            Definition::Expression(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    /// how/if this name is defined
+    pub fn get_definition(&self, name: &str) -> Definition {
         match self {
-            Scope::None | Scope::Root(_) => Some(Gc::new(Expr {
+            Scope::None | Scope::Root(_) => Definition::Expression(Gc::new(Expr {
                 range: None,
                 value: GcCell::new(None),
                 source: ExprSource::Literal {
@@ -62,14 +93,124 @@ impl Scope {
                         "true" => NixValue::Bool(true),
                         "false" => NixValue::Bool(false),
                         "null" => NixValue::Null,
-                        _ => return None,
+                        // list obtained with `nix repl` tab completion
+                        "abort"
+                        | "__add"
+                        | "__addErrorContext"
+                        | "__all"
+                        | "__any"
+                        | "__appendContext"
+                        | "__attrNames"
+                        | "__attrValues"
+                        | "baseNameOf"
+                        | "__bitAnd"
+                        | "__bitOr"
+                        | "__bitXor"
+                        | "builtins"
+                        | "__catAttrs"
+                        | "__ceil"
+                        | "__compareVersions"
+                        | "__concatLists"
+                        | "__concatMap"
+                        | "__concatStringsSep"
+                        | "__currentSystem"
+                        | "__currentTime"
+                        | "__deepSeq"
+                        | "derivation"
+                        | "derivationStrict"
+                        | "dirOf"
+                        | "__div"
+                        | "__elem"
+                        | "__elemAt"
+                        | "fetchGit"
+                        | "fetchMercurial"
+                        | "fetchTarball"
+                        | "fetchTree"
+                        | "__fetchurl"
+                        | "__filter"
+                        | "__filterSource"
+                        | "__findFile"
+                        | "__floor"
+                        | "__foldl'"
+                        | "__fromJSON"
+                        | "fromTOML"
+                        | "__functionArgs"
+                        | "__genericClosure"
+                        | "__genList"
+                        | "__getAttr"
+                        | "__getContext"
+                        | "__getEnv"
+                        | "__groupBy"
+                        | "__hasAttr"
+                        | "__hasContext"
+                        | "__hashFile"
+                        | "__hashString"
+                        | "__head"
+                        | "import"
+                        | "__intersectAttrs"
+                        | "__isAttrs"
+                        | "__isBool"
+                        | "__isFloat"
+                        | "__isFunction"
+                        | "__isInt"
+                        | "__isList"
+                        | "isNull"
+                        | "__isPath"
+                        | "__isString"
+                        | "__langVersion"
+                        | "__length"
+                        | "__lessThan"
+                        | "__listToAttrs"
+                        | "map"
+                        | "__mapAttrs"
+                        | "__match"
+                        | "__mul"
+                        | "__nixPath"
+                        | "__nixVersion"
+                        | "__parseDrvName"
+                        | "__partition"
+                        | "__path"
+                        | "__pathExists"
+                        | "placeholder"
+                        | "__readDir"
+                        | "__readFile"
+                        | "removeAttrs"
+                        | "__replaceStrings"
+                        | "scopedImport"
+                        | "__seq"
+                        | "__sort"
+                        | "__split"
+                        | "__splitVersion"
+                        | "__storeDir"
+                        | "__storePath"
+                        | "__stringLength"
+                        | "__sub"
+                        | "__substring"
+                        | "__tail"
+                        | "throw"
+                        | "__toFile"
+                        | "__toJSON"
+                        | "__toPath"
+                        | "toString"
+                        | "__toXML"
+                        | "__tryEval"
+                        | "__typeOf"
+                        | "__unsafeDiscardOutputDependency"
+                        | "__unsafeDiscardStringContext"
+                        | "__unsafeGetAttrPos"
+                        | "__zipAttrsWith" => return Definition::Ambient,
+                        _ => return Definition::Unbound,
                     },
                 },
                 scope: Gc::new(Scope::None),
             })),
             Scope::Let { parent, contents } => match contents.borrow().get(name) {
-                Some(x) => Some(x.clone()),
-                None => parent.get_let(name),
+                Some(x) => Definition::Expression(x.clone()),
+                None => parent.get_definition(name),
+            },
+            Scope::FunctionArguments { parent, names } => match names.borrow().get(name) {
+                Some(_) => Definition::Argument,
+                None => parent.get_definition(name),
             },
         }
     }
@@ -79,6 +220,7 @@ impl Scope {
             Scope::None => None,
             Scope::Root(path) => Some(path.clone()),
             Scope::Let { parent, .. } => parent.root_path(),
+            Scope::FunctionArguments { parent, .. } => parent.root_path(),
         }
     }
 }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -32,6 +32,16 @@ pub enum Scope {
         /// names bound
         names: GcCell<HashSet<String>>,
     },
+    /// Binding introduced by `with`
+    With {
+        /// parent scope
+        ///
+        /// This is a synctatical relation: bindings introduced by with are always resolved after
+        /// other bindings, so this scope might be shadowed by its parent.
+        parent: Gc<Scope>,
+        /// the expression `e` in `with e;`
+        contents: Gc<Expr>,
+    },
     None,
 }
 
@@ -39,7 +49,6 @@ pub enum Scope {
 #[derive(Debug, Clone)]
 pub enum Definition {
     /// Might be either unbound or bound dynamically by `with`
-    #[allow(dead_code)]
     PossiblyDynamic,
     /// Here is the expression that defines this variable
     Expression(Gc<Expr>),
@@ -83,136 +92,152 @@ impl Scope {
 
     /// how/if this name is defined
     pub fn get_definition(&self, name: &str) -> Definition {
-        match self {
-            Scope::None | Scope::Root(_) => Definition::Expression(Gc::new(Expr {
-                range: None,
-                value: GcCell::new(None),
-                source: ExprSource::Literal {
-                    // TODO: add more keys here, such as `builtins`
-                    value: match name {
-                        "true" => NixValue::Bool(true),
-                        "false" => NixValue::Bool(false),
-                        "null" => NixValue::Null,
-                        // list obtained with `nix repl` tab completion
-                        "abort"
-                        | "__add"
-                        | "__addErrorContext"
-                        | "__all"
-                        | "__any"
-                        | "__appendContext"
-                        | "__attrNames"
-                        | "__attrValues"
-                        | "baseNameOf"
-                        | "__bitAnd"
-                        | "__bitOr"
-                        | "__bitXor"
-                        | "builtins"
-                        | "__catAttrs"
-                        | "__ceil"
-                        | "__compareVersions"
-                        | "__concatLists"
-                        | "__concatMap"
-                        | "__concatStringsSep"
-                        | "__currentSystem"
-                        | "__currentTime"
-                        | "__deepSeq"
-                        | "derivation"
-                        | "derivationStrict"
-                        | "dirOf"
-                        | "__div"
-                        | "__elem"
-                        | "__elemAt"
-                        | "fetchGit"
-                        | "fetchMercurial"
-                        | "fetchTarball"
-                        | "fetchTree"
-                        | "__fetchurl"
-                        | "__filter"
-                        | "__filterSource"
-                        | "__findFile"
-                        | "__floor"
-                        | "__foldl'"
-                        | "__fromJSON"
-                        | "fromTOML"
-                        | "__functionArgs"
-                        | "__genericClosure"
-                        | "__genList"
-                        | "__getAttr"
-                        | "__getContext"
-                        | "__getEnv"
-                        | "__groupBy"
-                        | "__hasAttr"
-                        | "__hasContext"
-                        | "__hashFile"
-                        | "__hashString"
-                        | "__head"
-                        | "import"
-                        | "__intersectAttrs"
-                        | "__isAttrs"
-                        | "__isBool"
-                        | "__isFloat"
-                        | "__isFunction"
-                        | "__isInt"
-                        | "__isList"
-                        | "isNull"
-                        | "__isPath"
-                        | "__isString"
-                        | "__langVersion"
-                        | "__length"
-                        | "__lessThan"
-                        | "__listToAttrs"
-                        | "map"
-                        | "__mapAttrs"
-                        | "__match"
-                        | "__mul"
-                        | "__nixPath"
-                        | "__nixVersion"
-                        | "__parseDrvName"
-                        | "__partition"
-                        | "__path"
-                        | "__pathExists"
-                        | "placeholder"
-                        | "__readDir"
-                        | "__readFile"
-                        | "removeAttrs"
-                        | "__replaceStrings"
-                        | "scopedImport"
-                        | "__seq"
-                        | "__sort"
-                        | "__split"
-                        | "__splitVersion"
-                        | "__storeDir"
-                        | "__storePath"
-                        | "__stringLength"
-                        | "__sub"
-                        | "__substring"
-                        | "__tail"
-                        | "throw"
-                        | "__toFile"
-                        | "__toJSON"
-                        | "__toPath"
-                        | "toString"
-                        | "__toXML"
-                        | "__tryEval"
-                        | "__typeOf"
-                        | "__unsafeDiscardOutputDependency"
-                        | "__unsafeDiscardStringContext"
-                        | "__unsafeGetAttrPos"
-                        | "__zipAttrsWith" => return Definition::Ambient,
-                        _ => return Definition::Unbound,
+        fn get_definition_rec(scope: &Scope, name: &str, possibly_dynamic: bool) -> Definition {
+            match scope {
+                Scope::None | Scope::Root(_) => Definition::Expression(Gc::new(Expr {
+                    range: None,
+                    value: GcCell::new(None),
+                    source: ExprSource::Literal {
+                        // TODO: add more keys here, such as `builtins`
+                        value: match name {
+                            "true" => NixValue::Bool(true),
+                            "false" => NixValue::Bool(false),
+                            "null" => NixValue::Null,
+                            // list obtained with `nix repl` tab completion
+                            "abort"
+                            | "__add"
+                            | "__addErrorContext"
+                            | "__all"
+                            | "__any"
+                            | "__appendContext"
+                            | "__attrNames"
+                            | "__attrValues"
+                            | "baseNameOf"
+                            | "__bitAnd"
+                            | "__bitOr"
+                            | "__bitXor"
+                            | "builtins"
+                            | "__catAttrs"
+                            | "__ceil"
+                            | "__compareVersions"
+                            | "__concatLists"
+                            | "__concatMap"
+                            | "__concatStringsSep"
+                            | "__currentSystem"
+                            | "__currentTime"
+                            | "__deepSeq"
+                            | "derivation"
+                            | "derivationStrict"
+                            | "dirOf"
+                            | "__div"
+                            | "__elem"
+                            | "__elemAt"
+                            | "fetchGit"
+                            | "fetchMercurial"
+                            | "fetchTarball"
+                            | "fetchTree"
+                            | "__fetchurl"
+                            | "__filter"
+                            | "__filterSource"
+                            | "__findFile"
+                            | "__floor"
+                            | "__foldl'"
+                            | "__fromJSON"
+                            | "fromTOML"
+                            | "__functionArgs"
+                            | "__genericClosure"
+                            | "__genList"
+                            | "__getAttr"
+                            | "__getContext"
+                            | "__getEnv"
+                            | "__groupBy"
+                            | "__hasAttr"
+                            | "__hasContext"
+                            | "__hashFile"
+                            | "__hashString"
+                            | "__head"
+                            | "import"
+                            | "__intersectAttrs"
+                            | "__isAttrs"
+                            | "__isBool"
+                            | "__isFloat"
+                            | "__isFunction"
+                            | "__isInt"
+                            | "__isList"
+                            | "isNull"
+                            | "__isPath"
+                            | "__isString"
+                            | "__langVersion"
+                            | "__length"
+                            | "__lessThan"
+                            | "__listToAttrs"
+                            | "map"
+                            | "__mapAttrs"
+                            | "__match"
+                            | "__mul"
+                            | "__nixPath"
+                            | "__nixVersion"
+                            | "__parseDrvName"
+                            | "__partition"
+                            | "__path"
+                            | "__pathExists"
+                            | "placeholder"
+                            | "__readDir"
+                            | "__readFile"
+                            | "removeAttrs"
+                            | "__replaceStrings"
+                            | "scopedImport"
+                            | "__seq"
+                            | "__sort"
+                            | "__split"
+                            | "__splitVersion"
+                            | "__storeDir"
+                            | "__storePath"
+                            | "__stringLength"
+                            | "__sub"
+                            | "__substring"
+                            | "__tail"
+                            | "throw"
+                            | "__toFile"
+                            | "__toJSON"
+                            | "__toPath"
+                            | "toString"
+                            | "__toXML"
+                            | "__tryEval"
+                            | "__typeOf"
+                            | "__unsafeDiscardOutputDependency"
+                            | "__unsafeDiscardStringContext"
+                            | "__unsafeGetAttrPos"
+                            | "__zipAttrsWith" => return Definition::Ambient,
+                            _ => {
+                                return if possibly_dynamic {
+                                    Definition::PossiblyDynamic
+                                } else {
+                                    Definition::Unbound
+                                }
+                            }
+                        },
                     },
+                    scope: Gc::new(Scope::None),
+                })),
+                Scope::Let { parent, contents } => match contents.borrow().get(name) {
+                    Some(x) => Definition::Expression(x.clone()),
+                    None => get_definition_rec(parent, name, possibly_dynamic),
                 },
-                scope: Gc::new(Scope::None),
-            })),
-            Scope::Let { parent, contents } => match contents.borrow().get(name) {
-                Some(x) => Definition::Expression(x.clone()),
-                None => parent.get_definition(name),
-            },
-            Scope::FunctionArguments { parent, names } => match names.borrow().get(name) {
-                Some(_) => Definition::Argument,
-                None => parent.get_definition(name),
-            },
+                Scope::FunctionArguments { parent, names } => match names.borrow().get(name) {
+                    Some(_) => Definition::Argument,
+                    None => get_definition_rec(parent, name, possibly_dynamic),
+                },
+                Scope::With {
+                    parent,
+                    contents: _,
+                } => {
+                    // trying to evaluate the content is not yet implemented
+                    get_definition_rec(parent, name, true)
+                }
+            }
         }
+        get_definition_rec(&self, name, false)
     }
 
     pub fn root_path(&self) -> Option<PathBuf> {
@@ -220,6 +245,7 @@ impl Scope {
             Scope::None => None,
             Scope::Root(path) => Some(path.clone()),
             Scope::Let { parent, .. } => parent.root_path(),
+            Scope::With { parent, .. } => parent.root_path(),
             Scope::FunctionArguments { parent, .. } => parent.root_path(),
         }
     }

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -4,7 +4,7 @@ use rnix::TextRange;
 
 use crate::{
     error::{EvalError, Located, ValueError},
-    eval::{Expr, ExprSource}, scope::Definition,
+    eval::{Expr, ExprSource, StringPartSource}, scope::Definition,
 };
 
 /// If this node is an identifier, should it be a variable name ?
@@ -72,6 +72,13 @@ fn visit(acc: &mut Vec<Located<ValueError>>, node: &Expr, ident_ctx: Ident) {
             for i in entries.values() {
                 if let Some(default) = i {
                     visit_result(acc, default, &node.range, IsVariable);
+                }
+            }
+        },
+        ExprSource::String { parts } => {
+            for i in parts.iter() {
+                if let StringPartSource::Expression(expr) = i {
+                    visit_result(acc, expr, &node.range, IsVariable);
                 }
             }
         },

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -68,6 +68,10 @@ fn visit(acc: &mut Vec<Located<ValueError>>, node: &Expr, ident_ctx: Ident) {
             visit_result(acc, body, &node.range, IsVariable);
             visit_result(acc, arg, &node.range, IsNotVariable);
         }
+        ExprSource::OrDefault { index, default } => {
+            visit_result(acc, index, &node.range, IsVariable);
+            visit_result(acc, default, &node.range, IsVariable);
+        }
         ExprSource::With { inner, body } => {
             visit_result(acc, body, &node.range, IsVariable);
             visit_result(acc, inner, &node.range, IsVariable);

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -50,6 +50,12 @@ fn visit(acc: &mut Vec<Located<ValueError>>, node: &Expr, ident_ctx: Ident) {
                 visit_result(acc, i, &node.range, IsVariable)
             }
         }
+        ExprSource::LetIn { definitions, body } => {
+            for i in definitions.iter() {
+                visit_result(acc, i, &node.range, IsVariable)
+            }
+            visit_result(acc, body, &node.range, IsVariable);
+        }
         ExprSource::KeyValuePair { key, value } => {
             visit_result(acc, key, &node.range, IsNotVariable);
             visit_result(acc, value, &node.range, IsVariable);

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -76,6 +76,10 @@ fn visit(acc: &mut Vec<Located<ValueError>>, node: &Expr, ident_ctx: Ident) {
             visit_result(acc, body, &node.range, IsVariable);
             visit_result(acc, inner, &node.range, IsVariable);
         }
+        ExprSource::Assert { condition, body } => {
+            visit_result(acc, body, &node.range, IsVariable);
+            visit_result(acc, condition, &node.range, IsVariable);
+        }
         ExprSource::Pattern { entries, .. } => {
             for i in entries.values() {
                 if let Some(default) = i {

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -75,6 +75,11 @@ fn visit(acc: &mut Vec<Located<ValueError>>, node: &Expr, ident_ctx: Ident) {
                 }
             }
         },
+        ExprSource::List { elements } => {
+            for i in elements.iter() {
+                visit_result(acc, i, &node.range, IsVariable);
+            }
+        },
         ExprSource::Ident { name } => {
             if ident_ctx == IsVariable {
                 if let Some(range) = &node.range {

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -80,6 +80,11 @@ fn visit(acc: &mut Vec<Located<ValueError>>, node: &Expr, ident_ctx: Ident) {
             visit_result(acc, body, &node.range, IsVariable);
             visit_result(acc, condition, &node.range, IsVariable);
         }
+        ExprSource::IfElse { condition, body, else_body } => {
+            visit_result(acc, body, &node.range, IsVariable);
+            visit_result(acc, else_body, &node.range, IsVariable);
+            visit_result(acc, condition, &node.range, IsVariable);
+        }
         ExprSource::Pattern { entries, .. } => {
             for i in entries.values() {
                 if let Some(default) = i {

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -68,6 +68,10 @@ fn visit(acc: &mut Vec<Located<ValueError>>, node: &Expr, ident_ctx: Ident) {
             visit_result(acc, body, &node.range, IsVariable);
             visit_result(acc, arg, &node.range, IsNotVariable);
         }
+        ExprSource::With { inner, body } => {
+            visit_result(acc, body, &node.range, IsVariable);
+            visit_result(acc, inner, &node.range, IsVariable);
+        }
         ExprSource::Pattern { entries, .. } => {
             for i in entries.values() {
                 if let Some(default) = i {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -218,6 +218,18 @@ fn unbound_or_default_indexed() {
 }
 
 #[test]
+fn unbound_assert_condition() {
+    let code = "assert f; 1";
+    assert_eq!(static_analysis(code), hashmap! {"f" => "identifier f is unbound".into()});
+}
+
+#[test]
+fn unbound_assert_body() {
+    let code = "assert true; f";
+    assert_eq!(static_analysis(code), hashmap! {"f" => "identifier f is unbound".into()});
+}
+
+#[test]
 fn unbound_with() {
     let code = "with foo; 1";
     assert_eq!(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -200,6 +200,22 @@ fn bound_function_default_loop() {
 }
 
 #[test]
+fn unbound_string() {
+    let code = r#" "foo${bar}baz" "#;
+    assert_eq!(static_analysis(code), hashmap! {"bar" => "identifier bar is unbound".into()});
+}
+
+#[test]
+fn unbound_multiline_string() {
+    let code = r#" ''
+        foo
+        ${bar}
+    baz''
+"#;
+    assert_eq!(static_analysis(code), hashmap! {"bar" => "identifier bar is unbound".into()});
+}
+
+#[test]
 fn unbound_config() {
     let code = "{config, pkgs, ...}: { config = { services.xserver.enable = lib.mkForce true; }; }";
     assert_eq!(static_analysis(code), hashmap! {"lib" => "identifier lib is unbound".into()});

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -200,6 +200,21 @@ fn bound_function_default_loop() {
 }
 
 #[test]
+fn unbound_with() {
+    let code = "with foo; 1";
+    assert_eq!(
+        static_analysis(code),
+        hashmap! {"foo" => "identifier foo is unbound".into()}
+    );
+}
+
+#[test]
+fn maybe_bound_with() {
+    let code = "let inf = x: inf x; in with inf {}; bar";
+    assert_eq!(static_analysis(code), hashmap! {});
+}
+
+#[test]
 fn unbound_string() {
     let code = r#" "foo${bar}baz" "#;
     assert_eq!(static_analysis(code), hashmap! {"bar" => "identifier bar is unbound".into()});
@@ -224,7 +239,16 @@ fn unbound_config() {
 #[test]
 fn unbound_config2() {
     let code = "{config, pkgs, ...}: { config = { environment.systemPackages = [ (lib.hiPrio pkgs.sl) firefox ]; }";
-    assert_eq!(static_analysis(code), hashmap! {"lib" => "identifier lib is unbound".into(), "firefox" => "identifier firefox is unbound".into()});
+    assert_eq!(
+        static_analysis(code),
+        hashmap! {"lib" => "identifier lib is unbound".into(), "firefox" => "identifier firefox is unbound".into()}
+    );
+}
+
+#[test]
+fn maybe_bound_config3() {
+    let code = "{config, pkgs, ...}: { config = { environment.systemPackages = with pkgs; [ (lib.hiPrio sl) firefox ]; }";
+    assert_eq!(static_analysis(code), hashmap! {});
 }
 
 #[cfg(test)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -113,6 +113,15 @@ fn unbound_attrset() {
 }
 
 #[test]
+fn unbound_list() {
+    let code = "[ 1 t ]";
+    assert_eq!(
+        static_analysis(code),
+        hashmap! {"t" => "identifier t is unbound".into()}
+    );
+}
+
+#[test]
 fn bound_let() {
     let code = "let x = 1; y = x; in x + y";
     assert_eq!(static_analysis(code), hashmap! {});
@@ -194,6 +203,12 @@ fn bound_function_default_loop() {
 fn unbound_config() {
     let code = "{config, pkgs, ...}: { config = { services.xserver.enable = lib.mkForce true; }; }";
     assert_eq!(static_analysis(code), hashmap! {"lib" => "identifier lib is unbound".into()});
+}
+
+#[test]
+fn unbound_config2() {
+    let code = "{config, pkgs, ...}: { config = { environment.systemPackages = [ (lib.hiPrio pkgs.sl) firefox ]; }";
+    assert_eq!(static_analysis(code), hashmap! {"lib" => "identifier lib is unbound".into(), "firefox" => "identifier firefox is unbound".into()});
 }
 
 #[cfg(test)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -230,6 +230,24 @@ fn unbound_assert_body() {
 }
 
 #[test]
+fn unbound_if_condition() {
+    let code = "if foo then 1 else {}";
+    assert_eq!(static_analysis(code), hashmap! {"foo" => "identifier foo is unbound".into()});
+}
+
+#[test]
+fn unbound_if_body() {
+    let code = "if true then foo else {}";
+    assert_eq!(static_analysis(code), hashmap! {"foo" => "identifier foo is unbound".into()});
+}
+
+#[test]
+fn unbound_if_body_else() {
+    let code = "if true then 1 else foo";
+    assert_eq!(static_analysis(code), hashmap! {"foo" => "identifier foo is unbound".into()});
+}
+
+#[test]
 fn unbound_with() {
     let code = "with foo; 1";
     assert_eq!(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -248,6 +248,30 @@ fn unbound_if_body_else() {
 }
 
 #[test]
+fn bound_let_inherit() {
+    let code = "let foo = {a = 1;}; in let inherit (foo) a; in a";
+    assert_eq!(static_analysis(code), hashmap! {});
+}
+
+#[test]
+fn unbound_let_inherit() {
+    let code = "let foo = {a = 1;}; in let inherit (bar) a; in a";
+    assert_eq!(static_analysis(code), hashmap! {"bar" => "identifier bar is unbound".into()});
+}
+
+#[test]
+fn unbound_let_inherit2() {
+    let code = "let foo = {a = 1;}; in let inherit (foo) a; in aaaa";
+    assert_eq!(static_analysis(code), hashmap! {"aaaa" => "identifier aaaa is unbound".into()});
+}
+
+#[test]
+fn unbound_let_inherit3() {
+    let code = "let foo = {a = 1;}; in let inherit (foo) a; in a + bar";
+    assert_eq!(static_analysis(code), hashmap! {"bar" => "identifier bar is unbound".into()});
+}
+
+#[test]
 fn unbound_with() {
     let code = "with foo; 1";
     assert_eq!(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -200,6 +200,24 @@ fn bound_function_default_loop() {
 }
 
 #[test]
+fn bound_or_default() {
+    let code = "let s = {}; n = 1; in s.a or n";
+    assert_eq!(static_analysis(code), hashmap! {});
+}
+
+#[test]
+fn unbound_or_default() {
+    let code = "let s = {}; in s.a or n";
+    assert_eq!(static_analysis(code), hashmap! {"n" => "identifier n is unbound".into()});
+}
+
+#[test]
+fn unbound_or_default_indexed() {
+    let code = "in s.a or 1";
+    assert_eq!(static_analysis(code), hashmap! {"s" => "identifier s is unbound".into()});
+}
+
+#[test]
 fn unbound_with() {
     let code = "with foo; 1";
     assert_eq!(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -68,6 +68,18 @@ fn order_of_operations() {
 }
 
 #[test]
+fn eval_let() {
+    let code = "let x = 1; in x";
+    assert_eq!(eval(code).as_int().unwrap(), 1);
+}
+
+#[test]
+fn eval_let_sequential() {
+    let code = "let x = 1; y = x; in x + y";
+    assert_eq!(eval(code).as_int().unwrap(), 2);
+}
+
+#[test]
 fn div_int_by_float() {
     let code = "1 / 2.0";
     assert_eq!(eval(code).as_float().unwrap(), 0.5);
@@ -94,7 +106,46 @@ fn binding_analysis_ignores_attrset_selection() {
 #[test]
 fn unbound_attrset() {
     let code = "1 + rec { x = 1; y = x; z = t; }.y";
-    assert_eq!(static_analysis(code), hashmap!{"t" => "identifier t is unbound".into()});
+    assert_eq!(
+        static_analysis(code),
+        hashmap! {"t" => "identifier t is unbound".into()}
+    );
+}
+
+#[test]
+fn bound_let() {
+    let code = "let x = 1; y = x; in x + y";
+    assert_eq!(static_analysis(code), hashmap! {});
+}
+
+#[test]
+fn unbound_let_body() {
+    let code = "let x = 1; in x + y";
+    assert_eq!(
+        static_analysis(code),
+        hashmap! {"y" => "identifier y is unbound".into()}
+    );
+}
+
+#[test]
+fn unbound_let_defs() {
+    let code = "let x = t; y = u; in x + y";
+    assert_eq!(
+        static_analysis(code),
+        hashmap! {"t" => "identifier t is unbound".into(), "u" => "identifier u is unbound".into()}
+    );
+}
+
+#[test]
+fn bound_let_fixpoint() {
+    let code = "let x = x; in x";
+    assert_eq!(static_analysis(code), hashmap! {});
+}
+
+#[test]
+fn bound_let_recursive() {
+    let code = "let y = x; x = 1; in x - y";
+    assert_eq!(static_analysis(code), hashmap! {});
 }
 
 #[cfg(test)]


### PR DESCRIPTION
followup to #88 

parse all of rnix typed nodes so that unbound identifiers can be detected in much more cases

the evaluation machinery only returns unimplemented for the new nodes

![image](https://user-images.githubusercontent.com/12595971/180621918-4c0ce4f4-319a-4ef3-89c0-3bc9a31d1180.png)

at some point I ran rustfmt on the project by habit, I tried to undo some of the changes, but the diff is not minimal.