### PR TITLE
fix devShell for rust-analyzer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,8 +27,10 @@
           nativeBuildInputs = with pkgs; [
             rustc
             cargo
+            rustPlatform.rustLibSrc
             gitAndTools.pre-commit
           ];
+          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
         };
 
         apps.rnix-lsp = utils.lib.mkApp {

--- a/flake.nix
+++ b/flake.nix
@@ -27,10 +27,9 @@
           nativeBuildInputs = with pkgs; [
             rustc
             cargo
-            rustPlatform.rustLibSrc
             gitAndTools.pre-commit
           ];
-          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
         };
 
         apps.rnix-lsp = utils.lib.mkApp {


### PR DESCRIPTION
fix the rust-analyzer extension in vscode

error was

> rust-analyzer failed to load workspace: Failed to find sysroot for Cargo.toml ... Is rust-src installed?

based on
https://discourse.nixos.org/t/rust-src-not-found-and-other-misadventures-of-developing-rust-on-nixos/11570/2

